### PR TITLE
Add AddressMode and AddressModeWithOperand types

### DIFF
--- a/src/asm/instruction.rs
+++ b/src/asm/instruction.rs
@@ -76,7 +76,55 @@ pub enum Mnemonic {
     NOP,
 }
 
+// AddressMode represents the 6502 addressing mode only.
 pub enum AddressMode {
+    Accumlator,
+    Implied,
+    Immediate,
+    Absolute,
+    ZeroPage,
+    Relative,
+    AbsoluteIndirect,
+    AbsoluteIndexedWithX,
+    AbsoluteIndexedWithY,
+    ZeroPageIndexedWithX,
+    ZeroPageIndexedWithY,
+    ZeroPageIndexedIndirect,
+    ZeroPageIndirectIndexedWithY,
+}
+
+impl From<AddressModeWithOperand> for AddressMode {
+    fn from(am: AddressModeWithOperand) -> AddressMode {
+        let ref_am = am;
+        ref_am.into()
+    }
+}
+
+impl From<&AddressModeWithOperand> for AddressMode {
+    fn from(am: &AddressModeWithOperand) -> AddressMode {
+        match am {
+            AddressModeWithOperand::Accumlator => AddressMode::Accumlator,
+            AddressModeWithOperand::Implied => AddressMode::Implied,
+            AddressModeWithOperand::Immediate(_) => AddressMode::Immediate,
+            AddressModeWithOperand::Absolute(_) => AddressMode::Absolute,
+            AddressModeWithOperand::ZeroPage(_) => AddressMode::ZeroPage,
+            AddressModeWithOperand::Relative(_) => AddressMode::Relative,
+            AddressModeWithOperand::AbsoluteIndirect(_) => AddressMode::AbsoluteIndirect,
+            AddressModeWithOperand::AbsoluteIndexedWithX(_) => AddressMode::AbsoluteIndexedWithX,
+            AddressModeWithOperand::AbsoluteIndexedWithY(_) => AddressMode::AbsoluteIndexedWithY,
+            AddressModeWithOperand::ZeroPageIndexedWithX(_) => AddressMode::ZeroPageIndexedWithX,
+            AddressModeWithOperand::ZeroPageIndexedWithY(_) => AddressMode::ZeroPageIndexedWithY,
+            AddressModeWithOperand::ZeroPageIndexedIndirect(_) => {
+                AddressMode::ZeroPageIndexedIndirect
+            }
+            AddressModeWithOperand::ZeroPageIndirectIndexedWithY(_) => {
+                AddressMode::ZeroPageIndirectIndexedWithY
+            }
+        }
+    }
+}
+
+pub enum AddressModeWithOperand {
     Accumlator,
     Implied,
     Immediate(u8),

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -1,4 +1,0 @@
-#[cfg(test)]
-mod tests;
-
-mod instruction;

--- a/src/instruction_set/address_mode.rs
+++ b/src/instruction_set/address_mode.rs
@@ -18,13 +18,6 @@ pub enum AddressMode {
 
 impl From<AddressModeWithOperand> for AddressMode {
     fn from(am: AddressModeWithOperand) -> AddressMode {
-        let ref_am = am;
-        ref_am.into()
-    }
-}
-
-impl From<&AddressModeWithOperand> for AddressMode {
-    fn from(am: &AddressModeWithOperand) -> AddressMode {
         match am {
             AddressModeWithOperand::Accumlator => AddressMode::Accumlator,
             AddressModeWithOperand::Implied => AddressMode::Implied,
@@ -47,7 +40,8 @@ impl From<&AddressModeWithOperand> for AddressMode {
     }
 }
 
-/// AddressModeWithOperand captures the
+/// AddressModeWithOperand captures the Address mode type with a corresponding
+/// operand of the appropriate bit length.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum AddressModeWithOperand {
     Accumlator,
@@ -63,4 +57,36 @@ pub enum AddressModeWithOperand {
     ZeroPageIndexedWithY(u8),
     ZeroPageIndexedIndirect(u8),
     ZeroPageIndirectIndexedWithY(u8),
+}
+
+impl PartialEq<AddressMode> for AddressModeWithOperand {
+    fn eq(&self, other: &AddressMode) -> bool {
+        match self {
+            AddressModeWithOperand::Accumlator => *other == AddressMode::Accumlator,
+            AddressModeWithOperand::Implied => *other == AddressMode::Implied,
+            AddressModeWithOperand::Immediate(_) => *other == AddressMode::Immediate,
+            AddressModeWithOperand::Absolute(_) => *other == AddressMode::Absolute,
+            AddressModeWithOperand::ZeroPage(_) => *other == AddressMode::ZeroPage,
+            AddressModeWithOperand::Relative(_) => *other == AddressMode::Relative,
+            AddressModeWithOperand::AbsoluteIndirect(_) => *other == AddressMode::AbsoluteIndirect,
+            AddressModeWithOperand::AbsoluteIndexedWithX(_) => {
+                *other == AddressMode::AbsoluteIndexedWithX
+            }
+            AddressModeWithOperand::AbsoluteIndexedWithY(_) => {
+                *other == AddressMode::AbsoluteIndexedWithY
+            }
+            AddressModeWithOperand::ZeroPageIndexedWithX(_) => {
+                *other == AddressMode::ZeroPageIndexedWithX
+            }
+            AddressModeWithOperand::ZeroPageIndexedWithY(_) => {
+                *other == AddressMode::ZeroPageIndexedWithY
+            }
+            AddressModeWithOperand::ZeroPageIndexedIndirect(_) => {
+                *other == AddressMode::ZeroPageIndexedIndirect
+            }
+            AddressModeWithOperand::ZeroPageIndirectIndexedWithY(_) => {
+                *other == AddressMode::ZeroPageIndirectIndexedWithY
+            }
+        }
+    }
 }

--- a/src/instruction_set/address_mode.rs
+++ b/src/instruction_set/address_mode.rs
@@ -1,82 +1,5 @@
-pub enum Mnemonic {
-    // Load-Store
-    LDA,
-    LDX,
-    LDY,
-    STA,
-    STX,
-    STY,
-
-    // Arithmetic
-    ADC,
-    SBC,
-    INC,
-    INX,
-    INY,
-    DEC,
-    DEX,
-    DEY,
-
-    // Shift and Rotate
-    ASL,
-    LSR,
-    ROL,
-    ROR,
-    AND,
-    ORA,
-    EOR,
-
-    // Compare and Test Bit
-    CMP,
-    CPX,
-    CPY,
-    BIT,
-
-    // Branch
-    BCC,
-    BCS,
-    BNE,
-    BEQ,
-    BPL,
-    BMI,
-    BVC,
-    BVS,
-
-    // Transfer
-    TAX,
-    TXA,
-    TAY,
-    TYA,
-    TSX,
-    TXS,
-
-    // Stack
-    PHA,
-    PLA,
-    PHP,
-    PLP,
-
-    // Subroutines and Jump
-    JMP,
-    JSR,
-    RTS,
-    RTI,
-
-    // Set and Clear
-    CLC,
-    SEC,
-    CLD,
-    SED,
-    CLI,
-    SEI,
-    CLV,
-
-    // Misc
-    BRK,
-    NOP,
-}
-
 // AddressMode represents the 6502 addressing mode only.
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum AddressMode {
     Accumlator,
     Implied,
@@ -124,6 +47,8 @@ impl From<&AddressModeWithOperand> for AddressMode {
     }
 }
 
+/// AddressModeWithOperand captures the
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum AddressModeWithOperand {
     Accumlator,
     Implied,
@@ -138,9 +63,4 @@ pub enum AddressModeWithOperand {
     ZeroPageIndexedWithY(u8),
     ZeroPageIndexedIndirect(u8),
     ZeroPageIndirectIndexedWithY(u8),
-}
-
-pub struct Instruction {
-    instruction: Mnemonic,
-    address_mode: AddressMode,
 }

--- a/src/instruction_set/mnemonics.rs
+++ b/src/instruction_set/mnemonics.rs
@@ -1,0 +1,78 @@
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Mnemonic {
+    // Load-Store
+    LDA,
+    LDX,
+    LDY,
+    STA,
+    STX,
+    STY,
+
+    // Arithmetic
+    ADC,
+    SBC,
+    INC,
+    INX,
+    INY,
+    DEC,
+    DEX,
+    DEY,
+
+    // Shift and Rotate
+    ASL,
+    LSR,
+    ROL,
+    ROR,
+    AND,
+    ORA,
+    EOR,
+
+    // Compare and Test Bit
+    CMP,
+    CPX,
+    CPY,
+    BIT,
+
+    // Branch
+    BCC,
+    BCS,
+    BNE,
+    BEQ,
+    BPL,
+    BMI,
+    BVC,
+    BVS,
+
+    // Transfer
+    TAX,
+    TXA,
+    TAY,
+    TYA,
+    TSX,
+    TXS,
+
+    // Stack
+    PHA,
+    PLA,
+    PHP,
+    PLP,
+
+    // Subroutines and Jump
+    JMP,
+    JSR,
+    RTS,
+    RTI,
+
+    // Set and Clear
+    CLC,
+    SEC,
+    CLD,
+    SED,
+    CLI,
+    SEI,
+    CLV,
+
+    // Misc
+    BRK,
+    NOP,
+}

--- a/src/instruction_set/mod.rs
+++ b/src/instruction_set/mod.rs
@@ -1,0 +1,13 @@
+#[cfg(test)]
+mod tests;
+
+pub mod address_mode;
+pub mod mnemonics;
+
+/// Instruction represents a single 6502 instruction containing a mnemonic,
+/// address mode and optionally any operands.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Instruction {
+    mnemonic: mnemonics::Mnemonic,
+    address_mode: address_mode::AddressModeWithOperand,
+}

--- a/src/instruction_set/tests/mod.rs
+++ b/src/instruction_set/tests/mod.rs
@@ -1,0 +1,10 @@
+use crate::asm;
+
+#[test]
+fn test_statement_formatter_should_pretty_print_an_ast() {
+    let expr = Stmt::Expression(Expr::Unary(UnaryExpr::Minus(Box::new(Expr::Primary(
+        obj_number!(123.0),
+    )))));
+
+    assert_eq!("(Expression (- 123))".to_string(), format!("{}", expr))
+}

--- a/src/instruction_set/tests/mod.rs
+++ b/src/instruction_set/tests/mod.rs
@@ -1,10 +1,16 @@
-use crate::asm;
+use crate::instruction_set::address_mode::{AddressMode, AddressModeWithOperand};
 
 #[test]
-fn test_statement_formatter_should_pretty_print_an_ast() {
-    let expr = Stmt::Expression(Expr::Unary(UnaryExpr::Minus(Box::new(Expr::Primary(
-        obj_number!(123.0),
-    )))));
+fn address_mode_with_operand_should_cast_into_corresponding_address_mode_type() {
+    let amwo: AddressModeWithOperand = AddressModeWithOperand::Accumlator;
+    let am: AddressMode = amwo.into();
 
-    assert_eq!("(Expression (- 123))".to_string(), format!("{}", expr))
+    assert!(am == AddressMode::Accumlator);
+}
+
+#[test]
+fn address_mode_with_operand_should_be_comparable_to_address_mode() {
+    let amwo: AddressModeWithOperand = AddressModeWithOperand::Accumlator;
+
+    assert!(amwo == AddressMode::Accumlator);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 #[cfg(test)]
 mod tests;
 
-pub mod asm;
+pub mod instruction_set;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,1 @@
-#[test]
-fn it_works() {
-    assert_eq!(2 + 2, 4);
-}
+


### PR DESCRIPTION
# Introduction
This PR simplifies the `AddressMode` type and converts the old `AddressMode` type to an `AddressModeWithOperand` type. In addition, this PR implements traits to easy the comparison of the two types.

# Linked Issues
relates to #3 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
