### PR TITLE
Add LTO for release builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.release]
+lto = true
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # spasm
-A 6502 assembler for a modern age
+An experimental 6502 assembler.


### PR DESCRIPTION
# Introduction
Add LTO to release builds of spasm. this increases the build time slightly but cuts the binary size significantly.

```
vscode@cb2de4407fd9:/workspaces/spasm$ du -sh target/release/spasm
2.8M    target/release/spasm
vscode@cb2de4407fd9:/workspaces/spasm$ cargo build --release
    Finished release [optimized] target(s) in 0.00s
vscode@cb2de4407fd9:/workspaces/spasm$ du -sh target/release/spasm
1.1M    target/release/spasm
```
# Linked Issues
resolves #14 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
