### PR TITLE
Pad Binary to 32k

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update \
     # Install lldb, vadimcn.vscode-lldb VSCode extension dependencies
     && apt-get install -y lldb python3-minimal libpython3.7 \
     #
+    # Install debugging utilities
+    && apt-get install -y xxd \
     # Install Rust components
     && rustup update 2>&1 \
     && rustup component add rls rust-analysis rust-src rustfmt clippy 2>&1 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,13 @@
 {
 	"name": "Rust",
 	"dockerFile": "Dockerfile",
-	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
+	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"lldb.executable": "/usr/bin/lldb",
 		// VS Code don't watch files under ./target
@@ -14,22 +17,19 @@
 			"**/target/**": true
 		}
 	},
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"rust-lang.rust",
 		"bungcip.better-toml",
 		"vadimcn.vscode-lldb",
+		"ms-vscode.hexeditor",
 		// (Optional) Displays the current CPU stats, memory/disk consumption, clock freq. etc. of the container host in the VS Code status bar.
 		"mutantdino.resourcemonitor"
 	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub fn assemble(source: &str) -> AssemblerResult {
 
     Ok(insts
         .into_iter()
-        .map(|i| Into::<Vec<u8>>::into(i))
+        .map(Into::<Vec<u8>>::into)
         .flatten()
         .collect::<Vec<u8>>())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
 use std::process;
 
+const EXIT_SUCCESS: i32 = 0;
+const DATA_PADDING: usize = 32768;
 const HELP_STRING: &str = "A command-line 6502 assembler
 
 Usage: spasm <command> [*.asm]
@@ -63,7 +65,7 @@ fn write_dest_file(filename: &str, data: &[u8]) -> RuntimeResult<()> {
         .open(filename)
         .map_err(|_| RuntimeError::FileUnreadable)?;
 
-    match f.write(data) {
+    match f.write_all(data) {
         Ok(_) => Ok(()),
         Err(e) => Err(RuntimeError::Undefined(e.to_string())),
     }
@@ -76,9 +78,16 @@ fn help() -> RuntimeResult<i32> {
 
 fn run(source: &str) -> RuntimeResult<i32> {
     let obj = assemble(source)
-        .map_err(|e| RuntimeError::Undefined(e.to_string()))
+        .map_err(RuntimeError::Undefined)
         .map(|bin| bin)?;
+    let data_len = obj.len();
+    let padding = DATA_PADDING - data_len;
+    let mut bin: Vec<u8> = obj.into_iter().chain((0..padding).map(|_| 0xea)).collect();
 
-    write_dest_file("obj.bin", &obj)?;
-    Ok(0)
+    // reset vector
+    bin[0x7ffc] = 0x00;
+    bin[0x7ffd] = 0x80;
+
+    write_dest_file("a.out", &bin)?;
+    Ok(EXIT_SUCCESS)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,6 @@ fn run(source: &str) -> RuntimeResult<i32> {
         .map_err(|e| RuntimeError::Undefined(e.to_string()))
         .map(|bin| bin)?;
 
-    println!("obj, {:x?}", &obj);
-
     write_dest_file("obj.bin", &obj)?;
     Ok(0)
 }


### PR DESCRIPTION
# Introduction
This PR pads each output binary to 32K and sets the reset vector to the beginning of the binary.

This makes a ton of assumptions about the memory map, which is fine for now but will need to be generalized in the future.
# Linked Issues
resolves #19 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
