### PR TITLE
Properly parse EOF at the end of the last address mode in an instruction

### DIFF
--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -19,7 +19,7 @@ pub fn alphabetic<'a>() -> impl Parser<'a, &'a str, char> {
 pub fn eof<'a>() -> impl Parser<'a, &'a str, char> {
     move |input: &'a str| match input.chars().next() {
         Some(_) => Ok(MatchStatus::NoMatch(input)),
-        None => Ok(MatchStatus::Match((&input[1..], ' '))),
+        None => Ok(MatchStatus::Match((&input[0..], ' '))),
     }
 }
 

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -2,9 +2,9 @@ extern crate parcel;
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;
 
-pub fn whitespace<'a>() -> impl Parser<'a, &'a str, &'a str> {
+pub fn whitespace<'a>() -> impl Parser<'a, &'a str, char> {
     move |input: &'a str| match input.chars().next() {
-        Some(next) if next.is_whitespace() => Ok(MatchStatus::Match((&input[1..], &input[0..1]))),
+        Some(next) if next.is_whitespace() => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),
     }
 }
@@ -13,6 +13,13 @@ pub fn alphabetic<'a>() -> impl Parser<'a, &'a str, char> {
     move |input: &'a str| match input.chars().next() {
         Some(next) if next.is_alphabetic() => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+pub fn eof<'a>() -> impl Parser<'a, &'a str, char> {
+    move |input: &'a str| match input.chars().next() {
+        Some(_) => Ok(MatchStatus::NoMatch(input)),
+        None => Ok(MatchStatus::Match((&input[1..], ' '))),
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -39,9 +39,12 @@ pub fn instructions<'a>() -> impl parcel::Parser<'a, &'a str, Vec<Instruction>> 
 pub fn instruction<'a>() -> impl parcel::Parser<'a, &'a str, Instruction> {
     join(
         right(join(zero_or_more(whitespace()), mnemonic())),
-        right(join(
-            one_or_more(whitespace()),
-            optional(left(join(address_mode(), zero_or_more(whitespace())))),
+        left(join(
+            optional(right(join(
+                one_or_more(whitespace()),
+                left(join(address_mode(), zero_or_more(whitespace()))),
+            ))),
+            zero_or_more(whitespace()),
         )),
     )
     .map(|(m, a)| match a {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -81,7 +81,7 @@ fn accumulator<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
 fn absolute<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
     right(join(
         character('$'),
-        left(join(take_n(hex(), 4), one_or_more(whitespace()))),
+        left(join(take_n(hex(), 4), whitespace().or(|| eof()))),
     ))
     .map(|h| AddressMode::Absolute(hex_char_vec_to_u16!(h)))
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -151,7 +151,7 @@ fn relative<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
 fn zeropage<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
     right(join(
         character('$'),
-        left(join(take_n(hex(), 2), one_or_more(whitespace()))),
+        left(join(take_n(hex(), 2), whitespace().or(|| eof()))),
     ))
     .map(|h| AddressMode::ZeroPage(hex_char_vec_to_u8!(h)))
 }

--- a/src/parser/tests/address_mode.rs
+++ b/src/parser/tests/address_mode.rs
@@ -31,6 +31,11 @@ fn absolute_address_mode_should_match_valid_4_digit_hex_code() {
 }
 
 #[test]
+fn absolute_address_mode_should_match_eof_at_end_of_instruction() {
+    gen_am_test!("nop $1a2b", Mnemonic::NOP, AddressMode::Absolute(0x1a2b))
+}
+
+#[test]
 fn absolute_x_indexed_address_mode_should_match_valid_4_digit_hex_code() {
     gen_am_test!(
         "nop $1a2b,X\n",

--- a/src/parser/tests/address_mode.rs
+++ b/src/parser/tests/address_mode.rs
@@ -17,28 +17,24 @@ macro_rules! gen_am_test {
 
 #[test]
 fn implied_address_mode_should_match_if_no_address_mode_supplied() {
-    gen_am_test!("nop\n", Mnemonic::NOP, AddressMode::Implied)
+    gen_am_test!("nop", Mnemonic::NOP, AddressMode::Implied)
 }
 
 #[test]
 fn accumulator_address_mode_should_match_a() {
-    gen_am_test!("nop A\n", Mnemonic::NOP, AddressMode::Accumulator)
+    gen_am_test!("nop A", Mnemonic::NOP, AddressMode::Accumulator)
 }
 
 #[test]
 fn absolute_address_mode_should_match_valid_4_digit_hex_code() {
-    gen_am_test!("nop $1a2b\n", Mnemonic::NOP, AddressMode::Absolute(0x1a2b))
-}
-
-#[test]
-fn absolute_address_mode_should_match_eof_at_end_of_instruction() {
+    gen_am_test!("nop $1a2b\n", Mnemonic::NOP, AddressMode::Absolute(0x1a2b));
     gen_am_test!("nop $1a2b", Mnemonic::NOP, AddressMode::Absolute(0x1a2b))
 }
 
 #[test]
 fn absolute_x_indexed_address_mode_should_match_valid_4_digit_hex_code() {
     gen_am_test!(
-        "nop $1a2b,X\n",
+        "nop $1a2b,X",
         Mnemonic::NOP,
         AddressMode::AbsoluteIndexedWithX(0x1a2b)
     )
@@ -47,7 +43,7 @@ fn absolute_x_indexed_address_mode_should_match_valid_4_digit_hex_code() {
 #[test]
 fn absolute_y_indexed_address_mode_should_match_valid_4_digit_hex_code() {
     gen_am_test!(
-        "nop $1a2b,Y\n",
+        "nop $1a2b,Y",
         Mnemonic::NOP,
         AddressMode::AbsoluteIndexedWithY(0x1a2b)
     )
@@ -55,7 +51,7 @@ fn absolute_y_indexed_address_mode_should_match_valid_4_digit_hex_code() {
 
 #[test]
 fn immediate_address_mode_should_match_valid_2_digit_hex_code() {
-    gen_am_test!("nop #1a\n", Mnemonic::NOP, AddressMode::Immediate(0x1a))
+    gen_am_test!("nop #1a", Mnemonic::NOP, AddressMode::Immediate(0x1a))
 }
 
 #[test]
@@ -79,7 +75,7 @@ fn indexed_indirect_address_mode_should_match_valid_2_digit_hex_code() {
 #[test]
 fn indirect_indexed_address_mode_should_match_valid_2_digit_hex_code() {
     gen_am_test!(
-        "nop ($1a),Y\n",
+        "nop ($1a),Y",
         Mnemonic::NOP,
         AddressMode::IndirectIndexed(0x1a)
     )
@@ -88,18 +84,19 @@ fn indirect_indexed_address_mode_should_match_valid_2_digit_hex_code() {
 #[ignore]
 #[test]
 fn relative_address_mode_should_match_valid_2_digit_hex_code() {
-    gen_am_test!("nop $1a\n", Mnemonic::NOP, AddressMode::Relative(0x1a))
+    gen_am_test!("nop $1a", Mnemonic::NOP, AddressMode::Relative(0x1a))
 }
 
 #[test]
 fn zeropage_address_mode_should_match_valid_2_digit_hex_code() {
-    gen_am_test!("nop $1a\n", Mnemonic::NOP, AddressMode::ZeroPage(0x1a))
+    gen_am_test!("nop $1a\n", Mnemonic::NOP, AddressMode::ZeroPage(0x1a));
+    gen_am_test!("nop $1a", Mnemonic::NOP, AddressMode::ZeroPage(0x1a))
 }
 
 #[test]
 fn zeropage_x_indexed_address_mode_should_match_valid_2_digit_hex_code() {
     gen_am_test!(
-        "nop $1a,X\n",
+        "nop $1a,X",
         Mnemonic::NOP,
         AddressMode::ZeroPageIndexedWithX(0x1a)
     )
@@ -108,7 +105,7 @@ fn zeropage_x_indexed_address_mode_should_match_valid_2_digit_hex_code() {
 #[test]
 fn zeropage_y_indexed_address_mode_should_match_valid_2_digit_hex_code() {
     gen_am_test!(
-        "nop $1a,Y\n",
+        "nop $1a,Y",
         Mnemonic::NOP,
         AddressMode::ZeroPageIndexedWithY(0x1a)
     )

--- a/src/parser/tests/instructions.rs
+++ b/src/parser/tests/instructions.rs
@@ -28,3 +28,16 @@ fn should_strip_arbitrary_length_leading_chars_from_instruction() {
         instruction().parse(&input)
     );
 }
+
+#[test]
+fn should_succeed_if_eof_is_reached() {
+    let input = "    nop";
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[7..],
+            Instruction::new(Mnemonic::NOP, AddressMode::Implied)
+        ))),
+        instruction().parse(&input)
+    );
+}

--- a/src/parser/tests/mod.rs
+++ b/src/parser/tests/mod.rs
@@ -26,3 +26,24 @@ jmp $1234\n";
         instructions().parse(&input)
     );
 }
+
+#[test]
+fn should_parse_multiple_instructions_until_eof() {
+    let input = "nop
+lda #12
+sta $1234
+jmp $1234";
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[input.len()..],
+            vec![
+                Instruction::new(Mnemonic::NOP, AddressMode::Implied),
+                Instruction::new(Mnemonic::LDA, AddressMode::Immediate(0x12)),
+                Instruction::new(Mnemonic::STA, AddressMode::Absolute(0x1234)),
+                Instruction::new(Mnemonic::JMP, AddressMode::Absolute(0x1234))
+            ]
+        ))),
+        instructions().parse(&input)
+    );
+}


### PR DESCRIPTION
# Introduction
This PR fixes a bug where an EOF instead of a newline would cause some instructions to fail to parse their address mode. An example of this would be`jmp $1a2b\n` while `jmp $1a2b` would parse the `jmp` instruction but fail to parse the address mode. This PR introduces better handling of EOF alongside whitespace.

# Linked Issues
resolves #24 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
