### PR TITLE
Switch devcontainer to rust-analyzer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"rust-lang.rust",
+		"matklad.rust-analyzer",
 		"bungcip.better-toml",
 		"vadimcn.vscode-lldb",
 		"ms-vscode.hexeditor",


### PR DESCRIPTION
# Introduction
This PR updates the VSCode devcontainer to use rust-analyzer per the Rust documentation.
# Linked Issues
resolve #27 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
