### PR TITLE
Update cli to use scrap for command line tool management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,17 @@ version = "1.5.0"
 source = "git+https://github.com/ncatelli/parcel?tag=v1.6.0#6c01cf75438cbf2fd55c88a3a9065b54a0a43310"
 
 [[package]]
+name = "scrap"
+version = "0.1.0"
+source = "git+https://github.com/ncatelli/scrap?tag=v0.1.0#0e1b51915dd0df88d85cf75a6ae17a76dedf407f"
+dependencies = [
+ "parcel",
+]
+
+[[package]]
 name = "spasm"
 version = "0.1.0"
 dependencies = [
  "parcel",
+ "scrap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ lto = true
 
 [dependencies]
 parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.6.0" }
+scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.0" }


### PR DESCRIPTION
# Introduction
This PR updates spasm to use scrap for structuring its command and option parsing. This provides a few benefits including help output.

```bash
vscode@0058208e55a0:/workspaces/spasm$ ./target/debug/spasm --help
Usage: spasm [OPTIONS]
An experimental 6502 assembler.

Flags:
    --help, -h          print help string

Subcommands:
    assemble            assemble a source file into it's corresponding binary format
```

```bash
vscode@0058208e55a0:/workspaces/spasm$ ./target/debug/spasm assemble -i test.asm -o out.o
vscode@0058208e55a0:/workspaces/spasm$ 
```

# Linked Issues
resolves #18 
resolves #23 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
