### PR TITLE
Padding and Reset Vector Flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,21 +51,21 @@ fn main() {
                 .description("assemble a source file into it's corresponding binary format")
                 .flag(
                     Flag::new()
-                        .name("infile")
+                        .name("in-file")
                         .short_code("i")
                         .help_string("an asm source filepath to assemble")
                         .value_type(ValueType::Str),
                 )
                 .flag(
                     Flag::new()
-                        .name("outfile")
+                        .name("out-file")
                         .short_code("o")
                         .help_string("an output path for a the corresponding binary file")
                         .value_type(ValueType::Str)
                         .default_value(Value::Str("a.out".to_string())),
                 )
                 .handler(Box::new(|c| {
-                    match (c.get("infile"), c.get("outfile")) {
+                    match (c.get("in-file"), c.get("out-file")) {
                         (Some(Value::Str(in_f)), Some(Value::Str(out_f))) => read_src_file(&in_f)
                             .map(|input| run(&input, &out_f))
                             .and_then(std::convert::identity),


### PR DESCRIPTION
# Introduction
This PR adds two new flags `--padding` and `--reset-vector` to the `assemble` subcommand

## padding
Padding allows the specification of an output binary size. essentially padding all unused space with `nop` instructions.

## reset-vector
Reset Vector allows a user to specify the place of the first instruction as often times a memory map doesn't start at 0 (especially on 6502).

## Example

```bash
vscode@0058208e55a0:/workspaces/spasm$ ./target/debug/spasm assemble --help
Usage: assemble [OPTIONS]
assemble a source file into it's corresponding binary format

Flags:
    --help, -h          print help string
    --in-file, -i       an asm source filepath to assemble
    --out-file, -o      an output path for a the corresponding binary file
    --reset-vector, -r  the address offset of the starting byte of rom
    --padding, -p       size in bytes to pad the output binary to
vscode@0058208e55a0:/workspaces/spasm$ ./target/debug/spasm assemble -i test.asm -o out.o -r 32768 -p 32768
```

# Linked Issues
resolves #21 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
