### PR TITLE
Adds comment parsing to grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,52 @@
 # spasm
 An experimental 6502 assembler.
 
+## Grammar
+
+```
+program        = instruction* ;
+
+instruction    = mnemonic operand ("\n" | EOF) ;
+
+mnemonic       = "LDA" | "lda" | "LDX" | "ldx" | "LDY" | "ldy"
+               | "STA" | "sta" | "STX" | "stx" | "STY" | "sty"
+               | "ADC" | "adc" | "SBC" | "sbc"
+               | "INC" | "inc" | "INX" | "inx" | "INY" | "iny"
+               | "DEC" | "dec" | "DEX" | "dex" | "DEY" | "dey"
+               | "ASL" | "asl" | "LSR" | "lsr"
+               | "ROL" | "rol" | "ROR" | "ror"
+               | "AND" | "and" | "ORA" | "ora" | "EOR" | "eor"
+               | "CMP" | "cmp" | "CPX" | "cpx" | "CPY" | "cpy"
+               | "BIT" | "bit"
+               | "BCC" | "bcc" | "BCS" | "bcs"
+               | "BNE" | "bne" | "BEQ" | "beq"
+               | "BPL" | "bpl" | "BMI" | "bmi"
+               | "BVC" | "bvc" | "BVS" | "bvs"
+               | "TAX" | "tax" | TXA" | "txa"
+               | "TAY" | "tay" | "TYA" | "tya"
+               | "TSX" | "tsx" | "TXS" | "txs"
+               | "PHA" | "pha" | "PLA" | "pla"
+               | "PHP" | "php" | "PLP" | "plp"
+               | "JMP" | "jmp" | "JSR" | "jsr"
+               | "RTS" | "rts" | "RTI" | "rti"
+               | "CLC" | "clc" | "CLD" | "cld" | "CLI" | "cli" | "CLV" | "clv"
+               | "SEC" | "sec" | "SED" | "sed" | SEI" | "sei"
+               | "BRK" | "brk" | "NOP" | "nop"
+
+operand        = accumulator 
+               | absolute
+               | absolute_x_indexed
+               | absolute_y_indexed
+               | immediate
+               | indirect
+               | x_indexed_indirect
+               | indirect_y_indexed
+               | relative
+               | zeropage
+               | zeropage_x_indexed
+               | zeropage_y_indexed
+```
+
 ## Warnings
 Please nobody use this. This is entirely an experiment to support insane restrictions I've imposed on myself to build a computer from first principles.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An experimental 6502 assembler.
 ## Grammar
 
 ```
-instructions   = (instruction | comment)* (newline | EOF) ;
+instructions   = (whitespace | newline)* (instruction | comment)* (newline | EOF) ;
 
 instruction    = whitespace* mnemonic (whitespace+ operand)? whitespace+ comment? ;
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An experimental 6502 assembler.
 ```
 instructions   = (instruction | comment)* (newline | EOF) ;
 
-instruction    = whitespace* mnemonic (whitespace+ operand)? (whitespace*)? comment? ;
+instruction    = whitespace* mnemonic (whitespace+ operand)? whitespace+ comment? ;
 
 mnemonic       = "LDA" | "lda" | "LDX" | "ldx" | "LDY" | "ldy"
                | "STA" | "sta" | "STX" | "stx" | "STY" | "sty"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ operand        = accumulator
                | zeropage_x_indexed
                | zeropage_y_indexed
 
-comment        = ";" character* ;
+comment        = ";" (whitespace | character)* ;
 
 lower          = a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z
 upper          = A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ An experimental 6502 assembler.
 ## Grammar
 
 ```
-program        = instruction* ;
+program        = (instruction | comment)* ("\n" | EOF) ;
 
-instruction    = mnemonic operand ("\n" | EOF) ;
+instruction    = mnemonic operand comment? ;
 
 mnemonic       = "LDA" | "lda" | "LDX" | "ldx" | "LDY" | "ldy"
                | "STA" | "sta" | "STX" | "stx" | "STY" | "sty"
@@ -45,6 +45,14 @@ operand        = accumulator
                | zeropage
                | zeropage_x_indexed
                | zeropage_y_indexed
+
+comment        = ";" character* ;
+
+lower          = a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z
+upper          = A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z
+digit          = 0|1|2|3|4|5|6|7|8|9
+special        = -|_|"|#|&|’|(|)|*|+|,|.|/|:|;|<|=|>
+character      = lower|upper|digit|special
 ```
 
 ## Warnings

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ An experimental 6502 assembler.
 ## Grammar
 
 ```
-program        = (instruction | comment)* ("\n" | EOF) ;
+instructions   = (instruction | comment)* (newline | EOF) ;
 
-instruction    = mnemonic operand comment? ;
+instruction    = whitespace* mnemonic (whitespace+ operand)? (whitespace*)? comment? ;
 
 mnemonic       = "LDA" | "lda" | "LDX" | "ldx" | "LDY" | "ldy"
                | "STA" | "sta" | "STX" | "stx" | "STY" | "sty"
@@ -53,6 +53,9 @@ upper          = A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z
 digit          = 0|1|2|3|4|5|6|7|8|9
 special        = -|_|"|#|&|’|(|)|*|+|,|.|/|:|;|<|=|>
 character      = lower|upper|digit|special
+whitespace     = " " | "\t"
+newline        = "\n"
+
 ```
 
 ## Warnings

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -2,9 +2,12 @@ extern crate parcel;
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;
 
+// whitespaces matches any wh
 pub fn whitespace<'a>() -> impl Parser<'a, &'a str, char> {
     move |input: &'a str| match input.chars().next() {
-        Some(next) if next.is_whitespace() => Ok(MatchStatus::Match((&input[1..], next))),
+        Some(next) if next.is_whitespace() && next != '\n' => {
+            Ok(MatchStatus::Match((&input[1..], next)))
+        }
         _ => Ok(MatchStatus::NoMatch(input)),
     }
 }
@@ -23,7 +26,18 @@ pub fn eof<'a>() -> impl Parser<'a, &'a str, char> {
     }
 }
 
-pub fn character<'a>(expected: char) -> impl Parser<'a, &'a str, char> {
+pub fn newline<'a>() -> impl Parser<'a, &'a str, char> {
+    expect_character('\n')
+}
+
+pub fn character<'a>() -> impl Parser<'a, &'a str, char> {
+    move |input: &'a str| match input.chars().next() {
+        Some(next) if !next.is_whitespace() => Ok(MatchStatus::Match((&input[1..], next))),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+pub fn expect_character<'a>(expected: char) -> impl Parser<'a, &'a str, char> {
     move |input: &'a str| match input.chars().next() {
         Some(next) if next == expected => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -31,11 +31,14 @@ macro_rules! hex_char_vec_to_i8 {
 mod tests;
 
 pub fn instructions<'a>() -> impl parcel::Parser<'a, &'a str, Vec<Instruction>> {
-    one_or_more(left(join(
-        instruction()
-            .map(|i| Some(i))
-            .or(|| comment().map(|_| None)),
-        newline().or(|| eof()),
+    one_or_more(right(join(
+        zero_or_more(whitespace().or(|| newline())),
+        left(join(
+            instruction()
+                .map(|i| Some(i))
+                .or(|| comment().map(|_| None)),
+            newline().or(|| eof()),
+        )),
     )))
     .map(|ioc| {
         ioc.into_iter()

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -55,7 +55,7 @@ fn comment<'a>() -> impl parcel::Parser<'a, &'a str, ()> {
 }
 
 fn mnemonic<'a>() -> impl parcel::Parser<'a, &'a str, Mnemonic> {
-    one_or_more(alphabetic())
+    take_n(alphabetic(), 3)
         .map(|m| Mnemonic::try_from(m.into_iter().collect::<String>().as_str()).unwrap())
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -40,7 +40,7 @@ pub fn instruction<'a>() -> impl parcel::Parser<'a, &'a str, Instruction> {
         right(join(zero_or_more(whitespace()), mnemonic())),
         left(join(
             optional(right(join(one_or_more(whitespace()), address_mode()))),
-            zero_or_more(whitespace()),
+            join(zero_or_more(whitespace()), optional(comment())),
         )),
     )
     .map(|(m, a)| match a {
@@ -51,7 +51,11 @@ pub fn instruction<'a>() -> impl parcel::Parser<'a, &'a str, Instruction> {
 
 #[allow(dead_code)]
 fn comment<'a>() -> impl parcel::Parser<'a, &'a str, ()> {
-    right(join(expect_character(';'), zero_or_more(character()))).map(|_| ())
+    right(join(
+        expect_character(';'),
+        zero_or_more(character().or(|| whitespace())),
+    ))
+    .map(|_| ())
 }
 
 fn mnemonic<'a>() -> impl parcel::Parser<'a, &'a str, Mnemonic> {

--- a/src/parser/tests/address_mode.rs
+++ b/src/parser/tests/address_mode.rs
@@ -4,11 +4,11 @@ use parcel::prelude::v1::*;
 use parcel::MatchStatus;
 
 macro_rules! gen_am_test {
-    ($input:literal, $inst:expr, $am:expr) => {
+    ($input:literal, $mnemonic:expr, $am:expr) => {
         assert_eq!(
             Ok(MatchStatus::Match((
                 &$input[$input.len()..],
-                Instruction::new($inst, $am)
+                Instruction::new($mnemonic, $am)
             ))),
             instruction().parse(&$input)
         );

--- a/src/parser/tests/address_mode.rs
+++ b/src/parser/tests/address_mode.rs
@@ -27,7 +27,6 @@ fn accumulator_address_mode_should_match_a() {
 
 #[test]
 fn absolute_address_mode_should_match_valid_4_digit_hex_code() {
-    gen_am_test!("nop $1a2b\n", Mnemonic::NOP, AddressMode::Absolute(0x1a2b));
     gen_am_test!("nop $1a2b", Mnemonic::NOP, AddressMode::Absolute(0x1a2b))
 }
 
@@ -56,17 +55,13 @@ fn immediate_address_mode_should_match_valid_2_digit_hex_code() {
 
 #[test]
 fn indirect_address_mode_should_match_valid_4_digit_hex_code() {
-    gen_am_test!(
-        "nop ($1a2b)\n",
-        Mnemonic::NOP,
-        AddressMode::Indirect(0x1a2b)
-    )
+    gen_am_test!("nop ($1a2b)", Mnemonic::NOP, AddressMode::Indirect(0x1a2b))
 }
 
 #[test]
 fn indexed_indirect_address_mode_should_match_valid_2_digit_hex_code() {
     gen_am_test!(
-        "nop ($1a,X)\n",
+        "nop ($1a,X)",
         Mnemonic::NOP,
         AddressMode::IndexedIndirect(0x1a)
     )
@@ -89,7 +84,6 @@ fn relative_address_mode_should_match_valid_2_digit_hex_code() {
 
 #[test]
 fn zeropage_address_mode_should_match_valid_2_digit_hex_code() {
-    gen_am_test!("nop $1a\n", Mnemonic::NOP, AddressMode::ZeroPage(0x1a));
     gen_am_test!("nop $1a", Mnemonic::NOP, AddressMode::ZeroPage(0x1a))
 }
 

--- a/src/parser/tests/instructions.rs
+++ b/src/parser/tests/instructions.rs
@@ -5,11 +5,11 @@ use parcel::MatchStatus;
 
 #[test]
 fn should_parse_valid_nop_instruction() {
-    let input = "nop\n";
+    let input = "nop";
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &input[4..],
+            &input[3..],
             Instruction::new(Mnemonic::NOP, AddressMode::Implied)
         ))),
         instruction().parse(&input)
@@ -18,11 +18,11 @@ fn should_parse_valid_nop_instruction() {
 
 #[test]
 fn should_strip_arbitrary_length_leading_chars_from_instruction() {
-    let input = "    nop\n";
+    let input = "    nop";
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &input[8..],
+            &input[7..],
             Instruction::new(Mnemonic::NOP, AddressMode::Implied)
         ))),
         instruction().parse(&input)

--- a/src/parser/tests/instructions.rs
+++ b/src/parser/tests/instructions.rs
@@ -3,41 +3,33 @@ use crate::parser::instruction;
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;
 
+macro_rules! gen_inst_test {
+    ($input:literal, $mnemonic:expr, $am:expr) => {
+        assert_eq!(
+            Ok(MatchStatus::Match((
+                &$input[$input.len()..],
+                Instruction::new($mnemonic, $am)
+            ))),
+            instruction().parse(&$input)
+        );
+    };
+}
+
 #[test]
 fn should_parse_valid_nop_instruction() {
-    let input = "nop";
-
-    assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[3..],
-            Instruction::new(Mnemonic::NOP, AddressMode::Implied)
-        ))),
-        instruction().parse(&input)
-    );
+    gen_inst_test!("nop", Mnemonic::NOP, AddressMode::Implied)
 }
 
 #[test]
 fn should_strip_arbitrary_length_leading_chars_from_instruction() {
-    let input = "    nop";
-
-    assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[7..],
-            Instruction::new(Mnemonic::NOP, AddressMode::Implied)
-        ))),
-        instruction().parse(&input)
-    );
+    gen_inst_test!("    nop", Mnemonic::NOP, AddressMode::Implied)
 }
 
 #[test]
-fn should_succeed_if_eof_is_reached() {
-    let input = "    nop";
-
-    assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[7..],
-            Instruction::new(Mnemonic::NOP, AddressMode::Implied)
-        ))),
-        instruction().parse(&input)
-    );
+fn should_parse_and_ignore_inline_comments() {
+    gen_inst_test!(
+        "    nop ; this is a comment",
+        Mnemonic::NOP,
+        AddressMode::Implied
+    )
 }

--- a/src/parser/tests/mod.rs
+++ b/src/parser/tests/mod.rs
@@ -1,49 +1,71 @@
 use crate::instruction_set::{AddressMode, Instruction, Mnemonic};
-use crate::parser::instructions;
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;
 
 mod address_mode;
 mod instructions;
 
+macro_rules! gen_program_test {
+    ($input:literal, $insts:expr) => {
+        assert_eq!(
+            Ok(MatchStatus::Match((&$input[$input.len()..], $insts))),
+            $crate::parser::instructions().parse(&$input)
+        );
+    };
+}
+
 #[test]
 fn should_parse_multiple_instructions() {
-    let input = "nop
+    gen_program_test!(
+        "nop
 lda #12
 sta $1234
-jmp $1234\n";
-
-    assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[input.len()..],
-            vec![
-                Instruction::new(Mnemonic::NOP, AddressMode::Implied),
-                Instruction::new(Mnemonic::LDA, AddressMode::Immediate(0x12)),
-                Instruction::new(Mnemonic::STA, AddressMode::Absolute(0x1234)),
-                Instruction::new(Mnemonic::JMP, AddressMode::Absolute(0x1234))
-            ]
-        ))),
-        instructions().parse(&input)
-    );
+jmp $1234\n",
+        vec![
+            Instruction::new(Mnemonic::NOP, AddressMode::Implied),
+            Instruction::new(Mnemonic::LDA, AddressMode::Immediate(0x12)),
+            Instruction::new(Mnemonic::STA, AddressMode::Absolute(0x1234)),
+            Instruction::new(Mnemonic::JMP, AddressMode::Absolute(0x1234))
+        ]
+    )
 }
 
 #[test]
 fn should_parse_multiple_instructions_until_eof() {
-    let input = "nop
+    gen_program_test!(
+        "nop
 lda #12
 sta $1234
-jmp $1234";
+jmp $1234",
+        vec![
+            Instruction::new(Mnemonic::NOP, AddressMode::Implied),
+            Instruction::new(Mnemonic::LDA, AddressMode::Immediate(0x12)),
+            Instruction::new(Mnemonic::STA, AddressMode::Absolute(0x1234)),
+            Instruction::new(Mnemonic::JMP, AddressMode::Absolute(0x1234))
+        ]
+    )
+}
 
-    assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[input.len()..],
-            vec![
-                Instruction::new(Mnemonic::NOP, AddressMode::Implied),
-                Instruction::new(Mnemonic::LDA, AddressMode::Immediate(0x12)),
-                Instruction::new(Mnemonic::STA, AddressMode::Absolute(0x1234)),
-                Instruction::new(Mnemonic::JMP, AddressMode::Absolute(0x1234))
-            ]
-        ))),
-        instructions().parse(&input)
-    );
+#[test]
+fn should_parse_singleline_comment() {
+    gen_program_test!(
+        "; test comment 
+",
+        vec![]
+    )
+}
+
+#[test]
+fn should_ignore_comment_lines() {
+    gen_program_test!(
+        "; nop
+lda #12 ; this is the first instruction
+sta $1234
+jmp $1234",
+        vec![
+            Instruction::new(Mnemonic::LDA, AddressMode::Immediate(0x12)),
+            Instruction::new(Mnemonic::STA, AddressMode::Absolute(0x1234)),
+            Instruction::new(Mnemonic::JMP, AddressMode::Absolute(0x1234))
+        ]
+    )
 }

--- a/src/parser/tests/mod.rs
+++ b/src/parser/tests/mod.rs
@@ -15,12 +15,12 @@ macro_rules! gen_program_test {
 }
 
 #[test]
-fn should_parse_multiple_instructions() {
+fn should_parse_multiple_instructions_until_eof() {
     gen_program_test!(
         "nop
 lda #12
 sta $1234
-jmp $1234\n",
+jmp $1234",
         vec![
             Instruction::new(Mnemonic::NOP, AddressMode::Implied),
             Instruction::new(Mnemonic::LDA, AddressMode::Immediate(0x12)),
@@ -31,10 +31,13 @@ jmp $1234\n",
 }
 
 #[test]
-fn should_parse_multiple_instructions_until_eof() {
+fn should_parse_arbitrary_newlines_and_whitespaces_before_instruction() {
     gen_program_test!(
-        "nop
+        "
+        
+        nop
 lda #12
+
 sta $1234
 jmp $1234",
         vec![


### PR DESCRIPTION
# Introduction
This PR adds comments to the asm spec allowing parsing both inline and on a line on their own. In addition this includes the start of a BNF-like spec.

## Example
Comments can be included on their own or inline as shown below.

```asm
; nop
lda #12 ; this is the first instruction
sta $1234
jmp $1234
```

# Linked Issues
resolves #20 
starts #33 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
