### PR TITLE
Fix hex address encodings and add dec encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ mnemonic       = "LDA" | "lda" | "LDX" | "ldx" | "LDY" | "ldy"
                | "SEC" | "sec" | "SED" | "sed" | SEI" | "sei"
                | "BRK" | "brk" | "NOP" | "nop"
 
-operand        = accumulator 
+operand        = accumulator
                | absolute
                | absolute_x_indexed
                | absolute_y_indexed
@@ -46,15 +46,33 @@ operand        = accumulator
                | zeropage_x_indexed
                | zeropage_y_indexed
 
+accumulator        = "A" ;
+absolute           = ( "$" hexword ) | number ;
+absolute_x_indexed = ( ( "$" hexword ) | number ) ",X" ;
+absolute_y_indexed = ( ( "$" hexword ) | number ) ",Y" ;
+immediate          = "#" (( "$" hexbyte ) | number ) ;
+indirect           = "(" ( ( "$" hexword ) | number ) ")";
+x_indexed_indirect = "(" ( ( "$" hexbyte ) | number ) ",X)" ;
+indirect_y_indexed = "(" ( ( "$" hexbyte ) | number ) "),X" ;
+relative           =  sign? ( ( "$" ( hexbyte ) | number ) ;
+zeropage           = ( "$" ( hexbyte ) | number ;
+zeropage_x_indexed = ( ( "$" hexbyte ) | number ) ",X" ;
+zeropage_y_indexed = ( ( "$" hexbyte ) | number ) ",Y" ;
+
 comment        = ";" (whitespace | character)* ;
 
-lower          = a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z
-upper          = A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z
-digit          = 0|1|2|3|4|5|6|7|8|9
-special        = -|_|"|#|&|’|(|)|*|+|,|.|/|:|;|<|=|>
-character      = lower|upper|digit|special
-whitespace     = " " | "\t"
-newline        = "\n"
+lower          = a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z ;
+upper          = A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z ;
+hexword        = hex hex hex hex;
+hexbyte        = hex hex ;
+hex            = 0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|A|B|C|D|E|F ;
+number         = digit+ ;
+sign           = "-" | "+" ;
+digit          = 0|1|2|3|4|5|6|7|8|9 ;
+special        = -|_|"|#|&|’|(|)|*|+|,|.|/|:|;|<|=|> ;
+character      = lower|upper|digit|special ;
+whitespace     = " " | "\t" ;
+newline        = "\n" ;
 
 ```
 

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -1,6 +1,41 @@
 extern crate parcel;
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;
+use parcel::{join, right, take_n};
+
+macro_rules! hex_char_vec_to_u16 {
+    ($chars:expr) => {
+        u16::from_le(u16::from_str_radix(&$chars.into_iter().collect::<String>(), 16).unwrap())
+    };
+}
+
+macro_rules! hex_char_vec_to_u8 {
+    ($chars:expr) => {
+        u8::from_le(u8::from_str_radix(&$chars.into_iter().collect::<String>(), 16).unwrap())
+    };
+}
+
+macro_rules! hex_char_vec_to_i8 {
+    ($chars:expr) => {
+        i8::from_le(i8::from_str_radix(&$chars.into_iter().collect::<String>(), 16).unwrap())
+    };
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Sign {
+    Positive,
+    Negative,
+}
+
+impl PartialEq<char> for Sign {
+    fn eq(&self, other: &char) -> bool {
+        match self {
+            &Self::Positive if *other == '+' => true,
+            &Self::Negative if *other == '-' => true,
+            _ => false,
+        }
+    }
+}
 
 // whitespaces matches any wh
 pub fn whitespace<'a>() -> impl Parser<'a, &'a str, char> {
@@ -44,8 +79,40 @@ pub fn expect_character<'a>(expected: char) -> impl Parser<'a, &'a str, char> {
     }
 }
 
+pub fn unsigned16<'a>() -> impl Parser<'a, &'a str, u16> {
+    right(join(expect_character('$'), hexbytes(2))).map(|hex| hex_char_vec_to_u16!(hex))
+}
+
+pub fn unsigned8<'a>() -> impl Parser<'a, &'a str, u8> {
+    right(join(expect_character('$'), hexbytes(1))).map(|hex| hex_char_vec_to_u8!(hex))
+}
+
+pub fn signed8<'a>() -> impl Parser<'a, &'a str, i8> {
+    join(sign(), right(join(expect_character('$'), hexbytes(1)))).map(|(sign, hex)| {
+        let signed_char_vec = if sign == Sign::Negative {
+            vec![vec!['-'], hex].into_iter().flatten().collect()
+        } else {
+            hex
+        };
+        hex_char_vec_to_i8!(signed_char_vec)
+    })
+}
+
+fn sign<'a>() -> impl Parser<'a, &'a str, Sign> {
+    expect_character('+')
+        .or(|| expect_character('-'))
+        .map(|c| match c {
+            '-' => Sign::Negative,
+            _ => Sign::Positive,
+        })
+}
+
+pub fn hexbytes<'a>(bytes: usize) -> impl Parser<'a, &'a str, Vec<char>> {
+    take_n(hexdigit(), bytes * 2)
+}
+
 #[allow(dead_code)]
-pub fn hex<'a>() -> impl Parser<'a, &'a str, char> {
+pub fn hexdigit<'a>() -> impl Parser<'a, &'a str, char> {
     move |input: &'a str| match input.chars().next() {
         Some(next) if next.is_ascii_hexdigit() => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -1,7 +1,7 @@
 extern crate parcel;
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;
-use parcel::{join, right, take_n};
+use parcel::{join, one_or_more, right, take_n};
 
 macro_rules! hex_char_vec_to_u16 {
     ($chars:expr) => {
@@ -80,15 +80,19 @@ pub fn expect_character<'a>(expected: char) -> impl Parser<'a, &'a str, char> {
 }
 
 pub fn unsigned16<'a>() -> impl Parser<'a, &'a str, u16> {
-    right(join(expect_character('$'), hexbytes(2))).map(|hex| hex_char_vec_to_u16!(hex))
+    right(join(expect_character('$'), hex_bytes(2)))
+        .map(|hex| hex_char_vec_to_u16!(hex))
+        .or(|| dec_u16())
 }
 
 pub fn unsigned8<'a>() -> impl Parser<'a, &'a str, u8> {
-    right(join(expect_character('$'), hexbytes(1))).map(|hex| hex_char_vec_to_u8!(hex))
+    right(join(expect_character('$'), hex_bytes(1)))
+        .map(|hex| hex_char_vec_to_u8!(hex))
+        .or(|| dec_u8())
 }
 
 pub fn signed8<'a>() -> impl Parser<'a, &'a str, i8> {
-    join(sign(), right(join(expect_character('$'), hexbytes(1)))).map(|(sign, hex)| {
+    join(sign(), right(join(expect_character('$'), hex_bytes(1)))).map(|(sign, hex)| {
         let signed_char_vec = if sign == Sign::Negative {
             vec![vec!['-'], hex].into_iter().flatten().collect()
         } else {
@@ -107,14 +111,61 @@ fn sign<'a>() -> impl Parser<'a, &'a str, Sign> {
         })
 }
 
-pub fn hexbytes<'a>(bytes: usize) -> impl Parser<'a, &'a str, Vec<char>> {
-    take_n(hexdigit(), bytes * 2)
+pub fn hex_bytes<'a>(bytes: usize) -> impl Parser<'a, &'a str, Vec<char>> {
+    take_n(hex_digit(), bytes * 2)
+}
+
+pub fn hex_digit<'a>() -> impl Parser<'a, &'a str, char> {
+    move |input: &'a str| match input.chars().next() {
+        Some(next) if next.is_digit(16) => Ok(MatchStatus::Match((&input[1..], next))),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
 }
 
 #[allow(dead_code)]
-pub fn hexdigit<'a>() -> impl Parser<'a, &'a str, char> {
+fn dec_u16<'a>() -> impl Parser<'a, &'a str, u16> {
+    move |input: &'a str| {
+        let preparsed_input = input;
+        let res = one_or_more(decimal())
+            .map(|digits| {
+                let vd: String = digits.into_iter().collect();
+                u16::from_str_radix(&vd, 10)
+            })
+            .parse(input);
+
+        match res {
+            Ok(MatchStatus::Match((rem, Ok(u)))) => Ok(MatchStatus::Match((rem, u))),
+            Ok(MatchStatus::Match((_, Err(_)))) => Ok(MatchStatus::NoMatch(preparsed_input)),
+            Ok(MatchStatus::NoMatch(rem)) => Ok(MatchStatus::NoMatch(rem)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn dec_u8<'a>() -> impl Parser<'a, &'a str, u8> {
+    move |input: &'a str| {
+        let preparsed_input = input;
+        let res = one_or_more(decimal())
+            .map(|digits| {
+                let vd: String = digits.into_iter().collect();
+                u8::from_str_radix(&vd, 10)
+            })
+            .parse(input);
+
+        match res {
+            Ok(MatchStatus::Match((rem, Ok(u)))) => Ok(MatchStatus::Match((rem, u))),
+            Ok(MatchStatus::Match((_, Err(_)))) => Ok(MatchStatus::NoMatch(preparsed_input)),
+            Ok(MatchStatus::NoMatch(rem)) => Ok(MatchStatus::NoMatch(rem)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn decimal<'a>() -> impl Parser<'a, &'a str, char> {
     move |input: &'a str| match input.chars().next() {
-        Some(next) if next.is_ascii_hexdigit() => Ok(MatchStatus::Match((&input[1..], next))),
+        Some(next) if next.is_digit(10) => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -60,17 +60,17 @@ fn mnemonic<'a>() -> impl parcel::Parser<'a, &'a str, Mnemonic> {
 #[allow(clippy::redundant_closure)]
 fn address_mode<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
     accumulator()
-        .or(|| absolute_x_indexed())
-        .or(|| absolute_y_indexed())
-        .or(|| absolute())
-        .or(|| immediate())
-        .or(|| indirect())
-        .or(|| x_indexed_indirect())
-        .or(|| indirect_y_indexed())
-        //        .or(|| relative())
         .or(|| zeropage())
         .or(|| zeropage_x_indexed())
         .or(|| zeropage_y_indexed())
+        .or(|| absolute_x_indexed())
+        .or(|| absolute_y_indexed())
+        .or(|| x_indexed_indirect())
+        .or(|| indirect_y_indexed())
+        .or(|| absolute())
+        .or(|| immediate())
+        .or(|| indirect())
+    //        .or(|| relative())
 }
 
 fn accumulator<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9,24 +9,6 @@ use std::convert::TryFrom;
 mod combinators;
 use combinators::*;
 
-macro_rules! hex_char_vec_to_u16 {
-    ($chars:expr) => {
-        u16::from_le(u16::from_str_radix(&$chars.into_iter().collect::<String>(), 16).unwrap())
-    };
-}
-
-macro_rules! hex_char_vec_to_u8 {
-    ($chars:expr) => {
-        u8::from_le(u8::from_str_radix(&$chars.into_iter().collect::<String>(), 16).unwrap())
-    };
-}
-
-macro_rules! hex_char_vec_to_i8 {
-    ($chars:expr) => {
-        i8::from_le(i8::from_str_radix(&$chars.into_iter().collect::<String>(), 16).unwrap())
-    };
-}
-
 #[cfg(test)]
 mod tests;
 
@@ -96,112 +78,87 @@ fn accumulator<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
 }
 
 fn absolute<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
-    right(join(expect_character('$'), take_n(hex(), 4)))
-        .map(|h| AddressMode::Absolute(hex_char_vec_to_u16!(h)))
+    unsigned16().map(|h| AddressMode::Absolute(h))
 }
 
 fn absolute_x_indexed<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
-    right(join(
-        expect_character('$'),
-        left(join(
-            take_n(hex(), 4),
-            join(expect_character(','), expect_character('X')),
-        )),
+    left(join(
+        unsigned16(),
+        join(expect_character(','), expect_character('X')),
     ))
-    .map(|h| AddressMode::AbsoluteIndexedWithX(hex_char_vec_to_u16!(h)))
+    .map(|h| AddressMode::AbsoluteIndexedWithX(h))
 }
 
 fn absolute_y_indexed<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
-    right(join(
-        expect_character('$'),
-        left(join(
-            take_n(hex(), 4),
-            join(expect_character(','), expect_character('Y')),
-        )),
+    left(join(
+        unsigned16(),
+        join(expect_character(','), expect_character('Y')),
     ))
-    .map(|h| AddressMode::AbsoluteIndexedWithY(hex_char_vec_to_u16!(h)))
+    .map(|h| AddressMode::AbsoluteIndexedWithY(h))
 }
 
 fn immediate<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
-    right(join(expect_character('#'), take_n(hex(), 2)))
-        .map(|h| AddressMode::Immediate(hex_char_vec_to_u8!(h)))
+    right(join(expect_character('#'), unsigned8())).map(|u| AddressMode::Immediate(u))
 }
 
 fn indirect<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
     right(join(
-        join(expect_character('('), expect_character('$')),
-        left(join(take_n(hex(), 4), expect_character(')'))),
+        expect_character('('),
+        left(join(unsigned16(), expect_character(')'))),
     ))
-    .map(|h| AddressMode::Indirect(hex_char_vec_to_u16!(h)))
+    .map(|bytes| AddressMode::Indirect(bytes))
 }
 
 fn x_indexed_indirect<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
     right(join(
-        join(expect_character('('), expect_character('$')),
+        expect_character('('),
         left(join(
-            take_n(hex(), 2),
+            unsigned8(),
             join(
                 join(expect_character(','), expect_character('X')),
                 expect_character(')'),
             ),
         )),
     ))
-    .map(|h| AddressMode::IndexedIndirect(hex_char_vec_to_u8!(h)))
+    .map(|u| AddressMode::IndexedIndirect(u))
 }
 
 fn indirect_y_indexed<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
     right(join(
-        join(expect_character('('), expect_character('$')),
+        expect_character('('),
         left(join(
-            take_n(hex(), 2),
+            unsigned8(),
             join(
                 join(expect_character(')'), expect_character(',')),
                 expect_character('Y'),
             ),
         )),
     ))
-    .map(|h| AddressMode::IndirectIndexed(hex_char_vec_to_u8!(h)))
+    .map(|u| AddressMode::IndirectIndexed(u))
 }
 
 // Needs implementation of signed bits
 #[allow(dead_code)]
 fn relative<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
-    right(join(
-        expect_character('*'),
-        join(
-            expect_character('+').or(|| expect_character('-')),
-            take_n(hex(), 2),
-        ),
-    ))
-    .map(|(_sign, h)| AddressMode::Relative(hex_char_vec_to_i8!(h)))
+    right(join(expect_character('*'), signed8())).map(|i| AddressMode::Relative(i))
 }
 
 fn zeropage<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
-    right(join(
-        expect_character('$'),
-        left(join(take_n(hex(), 2), whitespace().or(|| eof()))),
-    ))
-    .map(|h| AddressMode::ZeroPage(hex_char_vec_to_u8!(h)))
+    left(join(unsigned8(), whitespace().or(|| eof()))).map(|u| AddressMode::ZeroPage(u))
 }
 
 fn zeropage_x_indexed<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
-    right(join(
-        expect_character('$'),
-        left(join(
-            take_n(hex(), 2),
-            join(expect_character(','), expect_character('X')),
-        )),
+    left(join(
+        unsigned8(),
+        join(expect_character(','), expect_character('X')),
     ))
-    .map(|h| AddressMode::ZeroPageIndexedWithX(hex_char_vec_to_u8!(h)))
+    .map(|u| AddressMode::ZeroPageIndexedWithX(u))
 }
 
 fn zeropage_y_indexed<'a>() -> impl parcel::Parser<'a, &'a str, AddressMode> {
-    right(join(
-        expect_character('$'),
-        left(join(
-            take_n(hex(), 2),
-            join(expect_character(','), expect_character('Y')),
-        )),
+    left(join(
+        unsigned8(),
+        join(expect_character(','), expect_character('Y')),
     ))
-    .map(|h| AddressMode::ZeroPageIndexedWithY(hex_char_vec_to_u8!(h)))
+    .map(|u| AddressMode::ZeroPageIndexedWithY(u))
 }

--- a/src/parser/tests/address_mode.rs
+++ b/src/parser/tests/address_mode.rs
@@ -22,85 +22,120 @@ fn implied_address_mode_should_match_if_no_address_mode_supplied() {
 
 #[test]
 fn accumulator_address_mode_should_match_a() {
-    gen_am_test!("nop A", Mnemonic::NOP, AddressMode::Accumulator)
+    gen_am_test!("asl A", Mnemonic::ASL, AddressMode::Accumulator)
 }
 
 #[test]
-fn absolute_address_mode_should_match_valid_4_digit_hex_code() {
-    gen_am_test!("nop $1a2b", Mnemonic::NOP, AddressMode::Absolute(0x1a2b))
+fn absolute_address_mode_should_match_valid_u16() {
+    gen_am_test!("lda $1a2b", Mnemonic::LDA, AddressMode::Absolute(0x1a2b));
+    gen_am_test!("lda 6699", Mnemonic::LDA, AddressMode::Absolute(0x1a2b));
 }
 
 #[test]
-fn absolute_x_indexed_address_mode_should_match_valid_4_digit_hex_code() {
+fn absolute_x_indexed_address_mode_should_match_valid_u16() {
     gen_am_test!(
-        "nop $1a2b,X",
-        Mnemonic::NOP,
+        "adc $1a2b,X",
+        Mnemonic::ADC,
         AddressMode::AbsoluteIndexedWithX(0x1a2b)
-    )
+    );
+    gen_am_test!(
+        "adc 6699,X",
+        Mnemonic::ADC,
+        AddressMode::AbsoluteIndexedWithX(0x1a2b)
+    );
 }
 
 #[test]
-fn absolute_y_indexed_address_mode_should_match_valid_4_digit_hex_code() {
+fn absolute_y_indexed_address_mode_should_match_valid_u16() {
     gen_am_test!(
-        "nop $1a2b,Y",
-        Mnemonic::NOP,
+        "inc $1a2b,Y",
+        Mnemonic::INC,
         AddressMode::AbsoluteIndexedWithY(0x1a2b)
-    )
-}
-
-#[test]
-fn immediate_address_mode_should_match_valid_2_digit_hex_code() {
-    gen_am_test!("nop #$1a", Mnemonic::NOP, AddressMode::Immediate(0x1a))
-}
-
-#[test]
-fn indirect_address_mode_should_match_valid_4_digit_hex_code() {
-    gen_am_test!("nop ($1a2b)", Mnemonic::NOP, AddressMode::Indirect(0x1a2b))
-}
-
-#[test]
-fn indexed_indirect_address_mode_should_match_valid_2_digit_hex_code() {
+    );
     gen_am_test!(
-        "nop ($1a,X)",
-        Mnemonic::NOP,
+        "inc 6699,Y",
+        Mnemonic::INC,
+        AddressMode::AbsoluteIndexedWithY(0x1a2b)
+    );
+}
+
+#[test]
+fn immediate_address_mode_should_match_valid_u8() {
+    gen_am_test!("lda #$1a", Mnemonic::LDA, AddressMode::Immediate(0x1a));
+    gen_am_test!("lda #26", Mnemonic::LDA, AddressMode::Immediate(0x1a));
+}
+
+#[test]
+fn indirect_address_mode_should_match_valid_u16() {
+    gen_am_test!("jmp ($1a2b)", Mnemonic::JMP, AddressMode::Indirect(0x1a2b));
+    gen_am_test!("jmp (6699)", Mnemonic::JMP, AddressMode::Indirect(0x1a2b));
+}
+
+#[test]
+fn indexed_indirect_address_mode_should_match_valid_u8() {
+    gen_am_test!(
+        "sta ($1a,X)",
+        Mnemonic::STA,
         AddressMode::IndexedIndirect(0x1a)
-    )
+    );
+    gen_am_test!(
+        "sta (26,X)",
+        Mnemonic::STA,
+        AddressMode::IndexedIndirect(0x1a)
+    );
 }
 
 #[test]
-fn indirect_indexed_address_mode_should_match_valid_2_digit_hex_code() {
+fn indirect_indexed_address_mode_should_match_valid_u8() {
     gen_am_test!(
-        "nop ($1a),Y",
-        Mnemonic::NOP,
+        "eor ($1a),Y",
+        Mnemonic::EOR,
         AddressMode::IndirectIndexed(0x1a)
-    )
+    );
+    gen_am_test!(
+        "eor (26),Y",
+        Mnemonic::EOR,
+        AddressMode::IndirectIndexed(0x1a)
+    );
 }
 
 #[ignore]
 #[test]
-fn relative_address_mode_should_match_valid_2_digit_hex_code() {
-    gen_am_test!("nop $1a", Mnemonic::NOP, AddressMode::Relative(0x1a))
+fn relative_address_mode_should_match_valid_u8() {
+    gen_am_test!("bpl $1a", Mnemonic::BPL, AddressMode::Relative(0x1a));
+    gen_am_test!("bpl 26", Mnemonic::BPL, AddressMode::Relative(0x1a));
 }
 
 #[test]
-fn zeropage_address_mode_should_match_valid_2_digit_hex_code() {
-    gen_am_test!("nop $1a", Mnemonic::NOP, AddressMode::ZeroPage(0x1a))
+fn zeropage_address_mode_should_match_valid_u8() {
+    gen_am_test!("ldy $1a", Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
+    gen_am_test!("ldy 26", Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
 }
 
 #[test]
-fn zeropage_x_indexed_address_mode_should_match_valid_2_digit_hex_code() {
+fn zeropage_x_indexed_address_mode_should_match_valid_u8() {
     gen_am_test!(
-        "nop $1a,X",
-        Mnemonic::NOP,
+        "lda $1a,X",
+        Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithX(0x1a)
-    )
+    );
+    gen_am_test!(
+        "lda 26,X",
+        Mnemonic::LDA,
+        AddressMode::ZeroPageIndexedWithX(0x1a)
+    );
 }
 
 #[test]
-fn zeropage_y_indexed_address_mode_should_match_valid_2_digit_hex_code() {
+fn zeropage_y_indexed_address_mode_should_match_valid_u8() {
     gen_am_test!(
-        "nop $1a,Y",
-        Mnemonic::NOP,
+        "lda $1a,Y",
+        Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithY(0x1a)
-    )
+    );
+    gen_am_test!(
+        "lda 26,Y",
+        Mnemonic::LDA,
+        AddressMode::ZeroPageIndexedWithY(0x1a)
+    );
 }

--- a/src/parser/tests/address_mode.rs
+++ b/src/parser/tests/address_mode.rs
@@ -50,7 +50,7 @@ fn absolute_y_indexed_address_mode_should_match_valid_4_digit_hex_code() {
 
 #[test]
 fn immediate_address_mode_should_match_valid_2_digit_hex_code() {
-    gen_am_test!("nop #1a", Mnemonic::NOP, AddressMode::Immediate(0x1a))
+    gen_am_test!("nop #$1a", Mnemonic::NOP, AddressMode::Immediate(0x1a))
 }
 
 #[test]

--- a/src/parser/tests/mod.rs
+++ b/src/parser/tests/mod.rs
@@ -18,7 +18,7 @@ macro_rules! gen_program_test {
 fn should_parse_multiple_instructions_until_eof() {
     gen_program_test!(
         "nop
-lda #12
+lda #$12
 sta $1234
 jmp $1234",
         vec![
@@ -36,7 +36,7 @@ fn should_parse_arbitrary_newlines_and_whitespaces_before_instruction() {
         "
         
         nop
-lda #12
+lda #$12
 
 sta $1234
 jmp $1234",
@@ -62,7 +62,7 @@ fn should_parse_singleline_comment() {
 fn should_ignore_comment_lines() {
     gen_program_test!(
         "; nop
-lda #12 ; this is the first instruction
+lda #$12 ; this is the first instruction
 sta $1234
 jmp $1234",
         vec![

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,7 +5,7 @@ use parcel::MatchStatus;
 #[test]
 fn should_generate_expected_opcode() {
     let input = "nop
-lda #12
+lda #$12
 sta $1234
 jmp $1234\n";
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -6,7 +6,7 @@ use parcel::MatchStatus;
 fn should_generate_expected_opcode() {
     let input = "nop
 lda #$12
-sta $1234
+sta 4660
 jmp $1234\n";
 
     let insts = match instructions().parse(&input).unwrap() {


### PR DESCRIPTION
# Introduction
This PR fixes the way hex addresses are encoded, separating the address mode from it's corresponding value. By doing this, value in multiple representations can be assigned in the operand.

Currently this updates all hex representations to be prefixed with a `$` while decimal is represented literally.

## Examples

Below is an example of an absolute address mode lda with it's operand specified first in hex then in decicmal

```asm
lda $1a2b ; hex
lda 6699   ; dec
```

# Linked Issues
#28 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
