### PR TITLE
Add binary address mode operand encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,33 +47,39 @@ operand        = accumulator
                | zeropage_y_indexed
 
 accumulator        = "A" ;
-absolute           = ( "$" hexword ) | number ;
-absolute_x_indexed = ( ( "$" hexword ) | number ) ",X" ;
-absolute_y_indexed = ( ( "$" hexword ) | number ) ",Y" ;
-immediate          = "#" (( "$" hexbyte ) | number ) ;
-indirect           = "(" ( ( "$" hexword ) | number ) ")";
-x_indexed_indirect = "(" ( ( "$" hexbyte ) | number ) ",X)" ;
-indirect_y_indexed = "(" ( ( "$" hexbyte ) | number ) "),X" ;
-relative           =  sign? ( ( "$" ( hexbyte ) | number ) ;
-zeropage           = ( "$" ( hexbyte ) | number ;
-zeropage_x_indexed = ( ( "$" hexbyte ) | number ) ",X" ;
-zeropage_y_indexed = ( ( "$" hexbyte ) | number ) ",Y" ;
+absolute           = word ;
+absolute_x_indexed = word ",X" ;
+absolute_y_indexed = word ",Y" ;
+immediate          = "#" byte ;
+indirect           = "(" word ")";
+x_indexed_indirect = "(" byte ",X)" ;
+indirect_y_indexed = "(" byte "),Y" ;
+relative           =  sign? byte ;
+zeropage           = byte ;
+zeropage_x_indexed = byte ",X" ;
+zeropage_y_indexed = byte ",Y" ;
 
 comment        = ";" (whitespace | character)* ;
 
-lower          = a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z ;
-upper          = A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z ;
-hexword        = hex hex hex hex;
-hexbyte        = hex hex ;
-hex            = 0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|A|B|C|D|E|F ;
-number         = digit+ ;
-sign           = "-" | "+" ;
-digit          = 0|1|2|3|4|5|6|7|8|9 ;
-special        = -|_|"|#|&|’|(|)|*|+|,|.|/|:|;|<|=|> ;
 character      = lower|upper|digit|special ;
 whitespace     = " " | "\t" ;
 newline        = "\n" ;
-
+lower          = "a"|"b"|"c"|"d"|"e"|"f"|"g"|"h"|"i"|"j"|"k"|"l"|"m"
+               |"n"|"o"|"p"|"q"|"r"|"s"|"t"|"u"|"v"|"w"|"x"|"y"|"z" ;
+upper          = "A"|"B"|"C"|"D"|"E"|"F"|"G"|"H"|"I"|"J"|"K"|"L"|"M"
+               |"N"|"O"|"P"|"Q"|"R"|"S"|"T"|"U"|"V"|"W"|"X"|"Y"|"Z" ;
+word        = ( "$" hex hex hex hex ) | digit+ 
+            | binarybyte binarybyte ;
+byte        = ( "$" hex hex ) | digit+ | binarybyte ;
+hex            = "0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"a"|"b"|"c"
+               |"d"|"e"|"f"|"A"|"B"|"C"|"D"|"E"|"F" ;
+number         = digit+ ;
+sign           = "-" | "+" ;
+binarybyte     = binary binary binary binary binary binary binary binary ;
+binary         = "0" | "1" ;
+digit          = "0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9" ;
+special        = "-"|"_"|"\""|"#"|"&"|"’"|"("|")"|"*"|"+"|","|"."|"/"
+               |":"|";"|"<"|"="|">" ;
 ```
 
 ## Warnings

--- a/src/parser/tests/address_mode.rs
+++ b/src/parser/tests/address_mode.rs
@@ -29,6 +29,11 @@ fn accumulator_address_mode_should_match_a() {
 fn absolute_address_mode_should_match_valid_u16() {
     gen_am_test!("lda $1a2b", Mnemonic::LDA, AddressMode::Absolute(0x1a2b));
     gen_am_test!("lda 6699", Mnemonic::LDA, AddressMode::Absolute(0x1a2b));
+    gen_am_test!(
+        "lda %0001101000101011",
+        Mnemonic::LDA,
+        AddressMode::Absolute(0x1a2b)
+    );
 }
 
 #[test]
@@ -40,6 +45,11 @@ fn absolute_x_indexed_address_mode_should_match_valid_u16() {
     );
     gen_am_test!(
         "adc 6699,X",
+        Mnemonic::ADC,
+        AddressMode::AbsoluteIndexedWithX(0x1a2b)
+    );
+    gen_am_test!(
+        "adc %0001101000101011,X",
         Mnemonic::ADC,
         AddressMode::AbsoluteIndexedWithX(0x1a2b)
     );
@@ -57,18 +67,33 @@ fn absolute_y_indexed_address_mode_should_match_valid_u16() {
         Mnemonic::INC,
         AddressMode::AbsoluteIndexedWithY(0x1a2b)
     );
+    gen_am_test!(
+        "inc %0001101000101011,Y",
+        Mnemonic::INC,
+        AddressMode::AbsoluteIndexedWithY(0x1a2b)
+    );
 }
 
 #[test]
 fn immediate_address_mode_should_match_valid_u8() {
     gen_am_test!("lda #$1a", Mnemonic::LDA, AddressMode::Immediate(0x1a));
     gen_am_test!("lda #26", Mnemonic::LDA, AddressMode::Immediate(0x1a));
+    gen_am_test!(
+        "lda #%00011010",
+        Mnemonic::LDA,
+        AddressMode::Immediate(0x1a)
+    );
 }
 
 #[test]
 fn indirect_address_mode_should_match_valid_u16() {
     gen_am_test!("jmp ($1a2b)", Mnemonic::JMP, AddressMode::Indirect(0x1a2b));
     gen_am_test!("jmp (6699)", Mnemonic::JMP, AddressMode::Indirect(0x1a2b));
+    gen_am_test!(
+        "jmp (%0001101000101011)",
+        Mnemonic::JMP,
+        AddressMode::Indirect(0x1a2b)
+    );
 }
 
 #[test]
@@ -80,6 +105,11 @@ fn indexed_indirect_address_mode_should_match_valid_u8() {
     );
     gen_am_test!(
         "sta (26,X)",
+        Mnemonic::STA,
+        AddressMode::IndexedIndirect(0x1a)
+    );
+    gen_am_test!(
+        "sta (%00011010,X)",
         Mnemonic::STA,
         AddressMode::IndexedIndirect(0x1a)
     );
@@ -97,6 +127,11 @@ fn indirect_indexed_address_mode_should_match_valid_u8() {
         Mnemonic::EOR,
         AddressMode::IndirectIndexed(0x1a)
     );
+    gen_am_test!(
+        "eor (%00011010),Y",
+        Mnemonic::EOR,
+        AddressMode::IndirectIndexed(0x1a)
+    );
 }
 
 #[ignore]
@@ -104,12 +139,14 @@ fn indirect_indexed_address_mode_should_match_valid_u8() {
 fn relative_address_mode_should_match_valid_u8() {
     gen_am_test!("bpl $1a", Mnemonic::BPL, AddressMode::Relative(0x1a));
     gen_am_test!("bpl 26", Mnemonic::BPL, AddressMode::Relative(0x1a));
+    gen_am_test!("bpl %00011010", Mnemonic::BPL, AddressMode::Relative(0x1a));
 }
 
 #[test]
 fn zeropage_address_mode_should_match_valid_u8() {
     gen_am_test!("ldy $1a", Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
     gen_am_test!("ldy 26", Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
+    gen_am_test!("ldy %00011010", Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
 }
 
 #[test]
@@ -124,6 +161,11 @@ fn zeropage_x_indexed_address_mode_should_match_valid_u8() {
         Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithX(0x1a)
     );
+    gen_am_test!(
+        "lda %00011010,X",
+        Mnemonic::LDA,
+        AddressMode::ZeroPageIndexedWithX(0x1a)
+    );
 }
 
 #[test]
@@ -135,6 +177,11 @@ fn zeropage_y_indexed_address_mode_should_match_valid_u8() {
     );
     gen_am_test!(
         "lda 26,Y",
+        Mnemonic::LDA,
+        AddressMode::ZeroPageIndexedWithY(0x1a)
+    );
+    gen_am_test!(
+        "lda %00011010,Y",
         Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithY(0x1a)
     );

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,7 +5,7 @@ use parcel::MatchStatus;
 #[test]
 fn should_generate_expected_opcode() {
     let input = "nop
-lda #$12
+lda #%00010010
 sta 4660
 jmp $1234\n";
 


### PR DESCRIPTION
# Introduction
This PR finalizes the changes for #28 by adding a binary address mode operand that is prefixed by `%`.

## Example

Below are a `lda` instruction with an equivalent absolute address mode operand in both hex, dec and binary encodings respectively.

```asm
lda $1a2b
lda 6699
lda %0001101000101011
```
# Linked Issues
resolves #28 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
