### PR TITLE
Upgrade to parcel 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,17 +6,22 @@ version = "1.5.0"
 source = "git+https://github.com/ncatelli/parcel?tag=v1.6.0#6c01cf75438cbf2fd55c88a3a9065b54a0a43310"
 
 [[package]]
+name = "parcel"
+version = "1.8.0"
+source = "git+https://github.com/ncatelli/parcel?tag=v1.8.0#adcd04bec5b8bd7f09efe35c4a5d88b6a7df3928"
+
+[[package]]
 name = "scrap"
 version = "0.1.0"
 source = "git+https://github.com/ncatelli/scrap?tag=v0.1.0#0e1b51915dd0df88d85cf75a6ae17a76dedf407f"
 dependencies = [
- "parcel",
+ "parcel 1.5.0",
 ]
 
 [[package]]
 name = "spasm"
 version = "0.1.0"
 dependencies = [
- "parcel",
+ "parcel 1.8.0",
  "scrap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 lto = true
 
 [dependencies]
-parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.6.0" }
+parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.8.0" }
 scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@ type SymbolMap = HashMap<String, u8>;
 // Converts a source string to it's corresponding array of little endinan binary
 // opcodes.
 pub fn assemble(source: &str) -> AssemblerResult {
-    let (_, labels, symbols, insts) = match parser::instructions().parse(&source).unwrap() {
+    let src = source.chars().collect::<Vec<char>>();
+    let (_, labels, symbols, insts) = match parser::instructions().parse(&src).unwrap() {
         parcel::MatchStatus::Match((_, insts)) => Ok(insts),
         _ => Err("match error".to_string()),
     }?

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -1,4 +1,5 @@
 extern crate parcel;
+use parcel::parsers::character::expect_character;
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;
 use parcel::{join, one_or_more, optional, right, take_n};
@@ -37,58 +38,10 @@ impl PartialEq<char> for Sign {
     }
 }
 
-// whitespaces matches any wh
-pub fn whitespace<'a>() -> impl Parser<'a, &'a [char], char> {
-    move |input: &'a [char]| match input.get(0) {
-        Some(&next) if next.is_whitespace() && next != '\n' => {
-            Ok(MatchStatus::Match((&input[1..], next)))
-        }
-        _ => Ok(MatchStatus::NoMatch(input)),
-    }
-}
-
-pub fn alphabetic<'a>() -> impl Parser<'a, &'a [char], char> {
-    move |input: &'a [char]| match input.get(0) {
-        Some(&next) if next.is_alphabetic() => Ok(MatchStatus::Match((&input[1..], next))),
-        _ => Ok(MatchStatus::NoMatch(input)),
-    }
-}
-
-pub fn eof<'a>() -> impl Parser<'a, &'a [char], char> {
-    move |input: &'a [char]| match input.get(0) {
-        Some(_) => Ok(MatchStatus::NoMatch(input)),
-        None => Ok(MatchStatus::Match((&input[0..], ' '))),
-    }
-}
-
-pub fn newline<'a>() -> impl Parser<'a, &'a [char], char> {
-    expect_character('\n')
-}
-
-pub fn character<'a>() -> impl Parser<'a, &'a [char], char> {
+pub fn non_whitespace_character<'a>() -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
         Some(&next) if !next.is_whitespace() => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),
-    }
-}
-
-pub fn expect_character<'a>(expected: char) -> impl Parser<'a, &'a [char], char> {
-    move |input: &'a [char]| match input.get(0) {
-        Some(&next) if next == expected => Ok(MatchStatus::Match((&input[1..], next))),
-        _ => Ok(MatchStatus::NoMatch(input)),
-    }
-}
-
-pub fn expect_str<'a>(expected: &'static str) -> impl Parser<'a, &'a [char], String> {
-    move |input: &'a [char]| {
-        let preparse_input = input;
-        let expected_len = expected.len();
-        let next: String = input.iter().take(expected_len).collect();
-        if &next == expected {
-            Ok(MatchStatus::Match((&input[expected_len..], next)))
-        } else {
-            Ok(MatchStatus::NoMatch(preparse_input))
-        }
     }
 }
 

--- a/src/parser/tests/address_mode.rs
+++ b/src/parser/tests/address_mode.rs
@@ -4,7 +4,7 @@ use parcel::prelude::v1::*;
 use parcel::MatchStatus;
 
 macro_rules! gen_am_test {
-    ($input:literal, $mnemonic:expr, $am:expr) => {
+    ($input:expr, $mnemonic:expr, $am:expr) => {
         assert_eq!(
             Ok(MatchStatus::Match((
                 &$input[$input.len()..],
@@ -14,46 +14,59 @@ macro_rules! gen_am_test {
                     )
                 )
             ))),
-            instruction().parse(&$input)
+            instruction().parse($input)
         );
+    };
+}
+
+macro_rules! chars {
+    ($input:expr) => {
+        $input.chars().collect::<Vec<char>>()
     };
 }
 
 #[test]
 fn implied_address_mode_should_match_if_no_address_mode_supplied() {
-    gen_am_test!("nop", Mnemonic::NOP, AddressMode::Implied)
+    let input = chars!("nop");
+    gen_am_test!(&input, Mnemonic::NOP, AddressMode::Implied);
 }
 
 #[test]
 fn accumulator_address_mode_should_match_a() {
-    gen_am_test!("asl A", Mnemonic::ASL, AddressMode::Accumulator)
+    let input = chars!("asl A");
+
+    gen_am_test!(&input, Mnemonic::ASL, AddressMode::Accumulator);
 }
 
 #[test]
 fn absolute_address_mode_should_match_valid_u16() {
-    gen_am_test!("lda $1a2b", Mnemonic::LDA, AddressMode::Absolute(0x1a2b));
-    gen_am_test!("lda 6699", Mnemonic::LDA, AddressMode::Absolute(0x1a2b));
-    gen_am_test!(
-        "lda %0001101000101011",
-        Mnemonic::LDA,
-        AddressMode::Absolute(0x1a2b)
-    );
+    let hinput = chars!("lda $1a2b");
+    let binput = chars!("lda %0001101000101011");
+    let dinput = chars!("lda 6699");
+
+    gen_am_test!(&hinput, Mnemonic::LDA, AddressMode::Absolute(0x1a2b));
+    gen_am_test!(&binput, Mnemonic::LDA, AddressMode::Absolute(0x1a2b));
+    gen_am_test!(&dinput, Mnemonic::LDA, AddressMode::Absolute(0x1a2b));
 }
 
 #[test]
 fn absolute_x_indexed_address_mode_should_match_valid_u16() {
+    let hinput = chars!("adc $1a2b,X");
+    let binput = chars!("adc %0001101000101011,X");
+    let dinput = chars!("adc 6699,X");
+
     gen_am_test!(
-        "adc $1a2b,X",
+        &hinput,
         Mnemonic::ADC,
         AddressMode::AbsoluteIndexedWithX(0x1a2b)
     );
     gen_am_test!(
-        "adc 6699,X",
+        &binput,
         Mnemonic::ADC,
         AddressMode::AbsoluteIndexedWithX(0x1a2b)
     );
     gen_am_test!(
-        "adc %0001101000101011,X",
+        &dinput,
         Mnemonic::ADC,
         AddressMode::AbsoluteIndexedWithX(0x1a2b)
     );
@@ -61,18 +74,22 @@ fn absolute_x_indexed_address_mode_should_match_valid_u16() {
 
 #[test]
 fn absolute_y_indexed_address_mode_should_match_valid_u16() {
+    let hinput = chars!("inc $1a2b,Y");
+    let binput = chars!("inc %0001101000101011,Y");
+    let dinput = chars!("inc 6699,Y");
+
     gen_am_test!(
-        "inc $1a2b,Y",
+        &hinput,
         Mnemonic::INC,
         AddressMode::AbsoluteIndexedWithY(0x1a2b)
     );
     gen_am_test!(
-        "inc 6699,Y",
+        &binput,
         Mnemonic::INC,
         AddressMode::AbsoluteIndexedWithY(0x1a2b)
     );
     gen_am_test!(
-        "inc %0001101000101011,Y",
+        &dinput,
         Mnemonic::INC,
         AddressMode::AbsoluteIndexedWithY(0x1a2b)
     );
@@ -80,94 +97,92 @@ fn absolute_y_indexed_address_mode_should_match_valid_u16() {
 
 #[test]
 fn immediate_address_mode_should_match_valid_u8() {
-    gen_am_test!("lda #$1a", Mnemonic::LDA, AddressMode::Immediate(0x1a));
-    gen_am_test!("lda #26", Mnemonic::LDA, AddressMode::Immediate(0x1a));
-    gen_am_test!(
-        "lda #%00011010",
-        Mnemonic::LDA,
-        AddressMode::Immediate(0x1a)
-    );
+    let hinput = chars!("lda #$1a");
+    let binput = chars!("lda #%00011010");
+    let dinput = chars!("lda #26");
+
+    gen_am_test!(&hinput, Mnemonic::LDA, AddressMode::Immediate(0x1a));
+    gen_am_test!(&binput, Mnemonic::LDA, AddressMode::Immediate(0x1a));
+    gen_am_test!(&dinput, Mnemonic::LDA, AddressMode::Immediate(0x1a));
 }
 
 #[test]
 fn indirect_address_mode_should_match_valid_u16() {
-    gen_am_test!("jmp ($1a2b)", Mnemonic::JMP, AddressMode::Indirect(0x1a2b));
-    gen_am_test!("jmp (6699)", Mnemonic::JMP, AddressMode::Indirect(0x1a2b));
-    gen_am_test!(
-        "jmp (%0001101000101011)",
-        Mnemonic::JMP,
-        AddressMode::Indirect(0x1a2b)
-    );
+    let hinput = chars!("jmp ($1a2b)");
+    let binput = chars!("jmp (%0001101000101011)");
+    let dinput = chars!("jmp (6699)");
+
+    gen_am_test!(&hinput, Mnemonic::JMP, AddressMode::Indirect(0x1a2b));
+    gen_am_test!(&binput, Mnemonic::JMP, AddressMode::Indirect(0x1a2b));
+    gen_am_test!(&dinput, Mnemonic::JMP, AddressMode::Indirect(0x1a2b));
 }
 
 #[test]
 fn indexed_indirect_address_mode_should_match_valid_u8() {
-    gen_am_test!(
-        "sta ($1a,X)",
-        Mnemonic::STA,
-        AddressMode::IndexedIndirect(0x1a)
-    );
-    gen_am_test!(
-        "sta (26,X)",
-        Mnemonic::STA,
-        AddressMode::IndexedIndirect(0x1a)
-    );
-    gen_am_test!(
-        "sta (%00011010,X)",
-        Mnemonic::STA,
-        AddressMode::IndexedIndirect(0x1a)
-    );
+    let hinput = chars!("sta ($1a,X)");
+    let binput = chars!("sta (%00011010,X)");
+    let dinput = chars!("sta (26,X)");
+
+    gen_am_test!(&hinput, Mnemonic::STA, AddressMode::IndexedIndirect(0x1a));
+    gen_am_test!(&binput, Mnemonic::STA, AddressMode::IndexedIndirect(0x1a));
+    gen_am_test!(&dinput, Mnemonic::STA, AddressMode::IndexedIndirect(0x1a));
 }
 
 #[test]
 fn indirect_indexed_address_mode_should_match_valid_u8() {
-    gen_am_test!(
-        "eor ($1a),Y",
-        Mnemonic::EOR,
-        AddressMode::IndirectIndexed(0x1a)
-    );
-    gen_am_test!(
-        "eor (26),Y",
-        Mnemonic::EOR,
-        AddressMode::IndirectIndexed(0x1a)
-    );
-    gen_am_test!(
-        "eor (%00011010),Y",
-        Mnemonic::EOR,
-        AddressMode::IndirectIndexed(0x1a)
-    );
+    let hinput = chars!("eor ($1a),Y");
+    let binput = chars!("eor (%00011010),Y");
+    let dinput = chars!("eor (26),Y");
+
+    gen_am_test!(&hinput, Mnemonic::EOR, AddressMode::IndirectIndexed(0x1a));
+    gen_am_test!(&dinput, Mnemonic::EOR, AddressMode::IndirectIndexed(0x1a));
+    gen_am_test!(&binput, Mnemonic::EOR, AddressMode::IndirectIndexed(0x1a));
 }
 
 #[test]
 fn relative_address_mode_should_match_valid_u8() {
-    gen_am_test!("bpl *$1a", Mnemonic::BPL, AddressMode::Relative(0x1a));
-    gen_am_test!("bpl *26", Mnemonic::BPL, AddressMode::Relative(0x1a));
-    gen_am_test!("bpl *+26", Mnemonic::BPL, AddressMode::Relative(0x1a));
-    gen_am_test!("bpl *-26", Mnemonic::BPL, AddressMode::Relative(-26));
-    gen_am_test!("bpl *%00011010", Mnemonic::BPL, AddressMode::Relative(0x1a));
+    let hinput = chars!("bpl *$1a");
+    let binput = chars!("bpl *%00011010");
+    let dinput = chars!("bpl *26");
+    let dspinput = chars!("bpl *+26");
+    let dsninput = chars!("bpl *-26");
+
+    gen_am_test!(&hinput, Mnemonic::BPL, AddressMode::Relative(0x1a));
+    gen_am_test!(&dinput, Mnemonic::BPL, AddressMode::Relative(0x1a));
+    gen_am_test!(&dspinput, Mnemonic::BPL, AddressMode::Relative(0x1a));
+    gen_am_test!(&dsninput, Mnemonic::BPL, AddressMode::Relative(-26));
+    gen_am_test!(&binput, Mnemonic::BPL, AddressMode::Relative(0x1a));
 }
 
 #[test]
 fn zeropage_address_mode_should_match_valid_u8() {
-    gen_am_test!("ldy $1a", Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
-    gen_am_test!("ldy 26", Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
-    gen_am_test!("ldy %00011010", Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
+    let hinput = chars!("ldy $1a");
+    let binput = chars!("ldy %00011010");
+    let dinput = chars!("ldy 26");
+
+    gen_am_test!(&hinput, Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
+    gen_am_test!(&dinput, Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
+    gen_am_test!(&binput, Mnemonic::LDY, AddressMode::ZeroPage(0x1a));
 }
 
 #[test]
 fn zeropage_x_indexed_address_mode_should_match_valid_u8() {
+    let hinput = chars!("lda $1a,X");
+    let binput = chars!("lda %00011010,X");
+    let dinput = chars!("lda 26,X");
+
     gen_am_test!(
-        "lda $1a,X",
+        &hinput,
         Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithX(0x1a)
     );
     gen_am_test!(
-        "lda 26,X",
+        &dinput,
         Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithX(0x1a)
     );
     gen_am_test!(
-        "lda %00011010,X",
+        &binput,
         Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithX(0x1a)
     );
@@ -175,18 +190,22 @@ fn zeropage_x_indexed_address_mode_should_match_valid_u8() {
 
 #[test]
 fn zeropage_y_indexed_address_mode_should_match_valid_u8() {
+    let hinput = chars!("lda $1a,Y");
+    let dinput = chars!("lda 26,Y");
+    let binput = chars!("lda %00011010,Y");
+
     gen_am_test!(
-        "lda $1a,Y",
+        &hinput,
         Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithY(0x1a)
     );
     gen_am_test!(
-        "lda 26,Y",
+        &dinput,
         Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithY(0x1a)
     );
     gen_am_test!(
-        "lda %00011010,Y",
+        &binput,
         Mnemonic::LDA,
         AddressMode::ZeroPageIndexedWithY(0x1a)
     );

--- a/src/parser/tests/instructions.rs
+++ b/src/parser/tests/instructions.rs
@@ -4,7 +4,7 @@ use parcel::prelude::v1::*;
 use parcel::MatchStatus;
 
 macro_rules! gen_inst_test {
-    ($input:literal, $mnemonic:expr, $am:expr) => {
+    ($input:expr, $mnemonic:expr, $am:expr) => {
         assert_eq!(
             Ok(MatchStatus::Match((
                 &$input[$input.len()..],
@@ -14,26 +14,31 @@ macro_rules! gen_inst_test {
                     )
                 )
             ))),
-            instruction().parse(&$input)
+            instruction().parse($input)
         );
+    };
+}
+
+macro_rules! chars {
+    ($input:expr) => {
+        $input.chars().collect::<Vec<char>>()
     };
 }
 
 #[test]
 fn should_parse_valid_nop_instruction() {
-    gen_inst_test!("nop", Mnemonic::NOP, AddressMode::Implied)
+    let input = chars!("nop");
+    gen_inst_test!(&input, Mnemonic::NOP, AddressMode::Implied);
 }
 
 #[test]
 fn should_strip_arbitrary_length_leading_chars_from_instruction() {
-    gen_inst_test!("    nop", Mnemonic::NOP, AddressMode::Implied)
+    let input = chars!("    nop");
+    gen_inst_test!(&input, Mnemonic::NOP, AddressMode::Implied);
 }
 
 #[test]
 fn should_parse_and_ignore_inline_comments() {
-    gen_inst_test!(
-        "    nop ; this is a comment",
-        Mnemonic::NOP,
-        AddressMode::Implied
-    )
+    let input = chars!("    nop ; this is a comment");
+    gen_inst_test!(&input, Mnemonic::NOP, AddressMode::Implied);
 }


### PR DESCRIPTION
# Introduction
This PR updates spasm to parcel 1.8.0, switching many of the baked in parsers to leverage the character parsers provided by parcel. This required that the parser inputs be switched from an `&str` -> `&[char]`. However functionally no other changes happened outside of deleting code.

# Linked Issues
resolves #47 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
