### PR TITLE
Add cargo-binutils to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,3 +5,6 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+RUN rustup component add llvm-tools-preview \
+    && cargo install cargo-binutils


### PR DESCRIPTION
# Introduction
Small PR to add cargo-binutils to the devcontainer to add some nice wrappers around llvm-tools.

# Linked Issues
resolves #51 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
