### PR TITLE
Origin seperation of intructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This feature-set is small to begin with but functions to standardize and consoli
 ### Grammar
 
 ```
-statement      = ( whitespace | newline )* ( labeldef | symboldef | orientation | instruction | comment )+ comment? ( newline | EOF ) ;
+statement      = ( whitespace | newline )* ( labeldef | symboldef | origin | instruction | comment )+ comment? ( newline | EOF ) ;
 
 instruction    = ( alphabetic | digit | special | ";"! )+ ;
 
@@ -26,8 +26,7 @@ bytedef        = ".1byte" whitespace+ alphabetic* whitespace+ byte ;
 twobytedef     = ".2byte" whitespace+ alphabetic* whitespace+ byte byte ;
 fourbytedef    = ".4byte" whitespace+ alphabetic* whitespace+ byte byte byte byte ;
 
-orientation    = offset ;
-offset         = ".offset" whitespace+ byte byte byte byte ;
+origin         = ".origin" whitespace+ byte byte byte byte ;
 
 
 labeldef       = alphabetic* ":" ;

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ This feature-set is small to begin with but functions to standardize and consoli
 ### Grammar
 
 ```
-program        = ( origin | statement )+ ;
+program        = ( whitespace | newline )* ( origin | statement )+ ;
 
-statement      = ( whitespace | newline )* ( labeldef | symboldef | origin | instruction | comment )+ comment?  ( newline | EOF );
+statements     = statement+ ;
 
-instruction    = ( alphabetic | digit | special | ";"! )+ ;
+statement      = ( whitespace | newline )* ( labeldef | symboldef | instruction | comment ) comment?  ( newline | EOF );
+
+instruction    = alphabetic ( alphabetic | digit | special | ";"! )+ ;
 
 comment        = ";" ( whitespace | character )* ;
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ fourbytedef    = ".4byte" whitespace+ alphabetic* whitespace+ byte byte byte byt
 
 origin         = ".origin" whitespace+ byte byte byte byte ;
 
-
 labeldef       = alphabetic* ":" ;
 
 character      = lower|upper|digit|special ;
@@ -51,7 +50,7 @@ special        = "-"|"_"|"\""|"#"|"&"|"’"|"("|")"|"*"|"+"|","|"."|"/"
 
 ## Backends
 
-- [MOS6502](./backends/mos6502/README.md)
+- [MOS6502](./src/backends/mos6502/README.md)
 
 ## Warnings
 Please nobody use this. This is entirely an experiment to support insane restrictions I've imposed on myself to build a computer from first principles.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # spasm
-An experimental 6502 assembler.
+An experimental multi-target assembler assembler.
 
 ## Preparser
 The preparser functions to provide many quality-of-life features that were previously introduced in a single backend. These include:
@@ -14,7 +14,9 @@ This feature-set is small to begin with but functions to standardize and consoli
 ### Grammar
 
 ```
-statement      = ( whitespace | newline )* ( labeldef | symboldef | origin | instruction | comment )+ comment? ( newline | EOF ) ;
+program        = ( origin | statement )+ ;
+
+statement      = ( whitespace | newline )* ( labeldef | symboldef | origin | instruction | comment )+ comment?  ( newline | EOF );
 
 instruction    = ( alphabetic | digit | special | ";"! )+ ;
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An experimental multi-target assembler assembler.
 ## Preparser
 The preparser functions to provide many quality-of-life features that were previously introduced in a single backend. These include:
 
+- Origin and byte offsetting
 - Constants
     - Sized
 - Labels

--- a/src/addressing/mod.rs
+++ b/src/addressing/mod.rs
@@ -6,18 +6,12 @@ pub trait SizeOf {
 
 /// Positional functions to store an object wrapped with an offset position.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Positional<T>
-where
-    T: SizeOf,
-{
+pub struct Positional<T> {
     pub position: usize,
     contents: T,
 }
 
-impl<T> Positional<T>
-where
-    T: SizeOf,
-{
+impl<T> Positional<T> {
     /// new instantiates a Positional with an offset of 0 that wraps a value T.
     /// Essentially this calls Self::with_position(0, T).
     #[allow(dead_code)]

--- a/src/backends/README.md
+++ b/src/backends/README.md
@@ -1,9 +1,5 @@
 # MOS Technology 6502 Backend
 
-## Special Labels
-### init
-The `init` label holds special significance, defining the entrance into the program. The address at the `init` label will be set to the value of the reset vector.
-
 ## Grammar
 
 ```

--- a/src/backends/README.md
+++ b/src/backends/README.md
@@ -1,4 +1,9 @@
 # MOS Technology 6502 Backend
+
+## Special Labels
+### init
+The `init` label holds special significance, defining the entrance into the program. The address at the `init` label will be set to the value of the reset vector.
+
 ## Grammar
 
 ```

--- a/src/backends/README.md
+++ b/src/backends/README.md
@@ -1,5 +1,4 @@
 # MOS Technology 6502 Backend
-
 ## Grammar
 
 ```

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -113,7 +113,7 @@ impl Assembler<UnparsedTokenStream> for MOS6502Assembler {
 
         let opcodes = insts
             .into_iter()
-            .map(|pi| (pi.unwrap()))
+            .map(|pi| pi.unwrap())
             .map(|i| {
                 let mnemonic = i.mnemonic;
                 let amor = i.amor;

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -128,6 +128,8 @@ fn generate_symbol_table_from_instructions(
     Ok((symbol_table, tokens))
 }
 
+/// MOS6502Assembler functions as a wrapper struct to facilitate an
+/// implementation of the Assembler trait for the 6502 instruction set.
 #[derive(Default)]
 pub struct MOS6502Assembler {}
 

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -33,7 +33,7 @@ impl Assembler<Vec<Token<String>>> for MOS6502Assembler {
             .into_iter()
             .map(|tok| match tok {
                 Token::Label(v) => Ok(Token::Label(v)),
-                Token::Offset(u) => Ok(Token::Offset(u)),
+                Token::Origin(u) => Ok(Token::Origin(u)),
                 Token::Symbol(v) => Ok(Token::Symbol(v)),
                 Token::Instruction(inst) => {
                     let input = inst.chars().collect::<Vec<char>>();
@@ -76,7 +76,7 @@ impl Assembler<Vec<Token<String>>> for MOS6502Assembler {
                         symbols.insert(id, sv);
                         (offset, labels, symbols, insts)
                     }
-                    Token::Offset(o) => (o as usize, labels, symbols, insts),
+                    Token::Origin(o) => (o as usize, labels, symbols, insts),
                 },
             );
 

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -33,11 +33,6 @@ impl SymbolTable {
     fn new(labels: LabelMap, symbols: SymbolMap) -> Self {
         Self { labels, symbols }
     }
-
-    #[allow(dead_code)]
-    fn into_tuple(self) -> (LabelMap, SymbolMap) {
-        (self.labels, self.symbols)
-    }
 }
 
 impl From<Vec<SymbolTable>> for SymbolTable {

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -52,7 +52,6 @@ impl MOS6502Assembler {
             .into_iter()
             .map(|tok| match tok {
                 Token::Label(v) => Ok(Token::Label(v)),
-                Token::Origin(u) => Ok(Token::Origin(u)),
                 Token::Symbol(v) => Ok(Token::Symbol(v)),
                 Token::Instruction(inst) => {
                     let input = inst.chars().collect::<Vec<char>>();
@@ -102,7 +101,6 @@ impl Assembler<Vec<Token<String>>> for MOS6502Assembler {
                         symbols.insert(id, sv);
                         (offset, labels, symbols, insts)
                     }
-                    Token::Origin(o) => (o as usize, labels, symbols, insts),
                 },
             );
 

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -15,6 +15,9 @@ use crate::preparser::{ByteValue, Token};
 use crate::Emitter;
 use crate::{Assembler, AssemblerResult};
 
+type UnparsedTokenStream = Vec<Token<String>>;
+type ParsedTokenStream = Vec<Token<Instruction>>;
+
 type LabelMap = HashMap<String, u16>;
 type SymbolMap = HashMap<String, u8>;
 
@@ -46,8 +49,8 @@ impl MOS6502Assembler {
 
     fn parse_string_instructions_to_token(
         &self,
-        source: Vec<Token<String>>,
-    ) -> Result<Vec<Token<Instruction>>, String> {
+        source: UnparsedTokenStream,
+    ) -> Result<ParsedTokenStream, String> {
         source
             .into_iter()
             .map(|tok| match tok {
@@ -70,8 +73,8 @@ impl MOS6502Assembler {
     }
 }
 
-impl Assembler<Vec<Token<String>>> for MOS6502Assembler {
-    fn assemble(&self, source: Vec<Token<String>>) -> AssemblerResult {
+impl Assembler<UnparsedTokenStream> for MOS6502Assembler {
+    fn assemble(&self, source: UnparsedTokenStream) -> AssemblerResult {
         let (_, labels, symbols, insts) = self
             .parse_string_instructions_to_token(source)?
             .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,25 @@ pub trait Emitter<T> {
 }
 
 /// Origin provides a structure for denoting memory offsets.
-pub struct Origin<U> {
+pub struct Origin<T> {
     pub offset: usize,
-    pub instructions: U,
+    pub instructions: T,
+}
+
+impl<T> Origin<T> {
+    pub fn new(instructions: T) -> Self {
+        Self {
+            offset: 0,
+            instructions,
+        }
+    }
+
+    pub fn with_offset(offset: usize, instructions: T) -> Self {
+        Self {
+            offset,
+            instructions,
+        }
+    }
 }
 
 impl Emitter<Vec<u8>> for u8 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,11 @@ pub trait Assembler<T> {
 pub fn assemble(backend: Backend, source: &str) -> AssemblerResult {
     let input: Vec<char> = source.chars().collect();
     let origin_tokens = preparser::PreParser::new().parse(&input).unwrap().unwrap();
-    let tokens = origin_tokens.instructions; // This will need to eventually be removed.
+    let tokens = origin_tokens
+        .into_iter()
+        .map(|origin| origin.instructions)
+        .flatten()
+        .collect(); // This will need to eventually be removed.
 
     match backend {
         Backend::MOS6502 => backends::mos6502::MOS6502Assembler::new().assemble(tokens),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,15 +66,12 @@ impl Emitter<Vec<u8>> for Vec<u8> {
 impl Emitter<Vec<u8>> for Vec<Origin<Vec<u8>>> {
     fn emit(&self) -> Vec<u8> {
         let mut origins = self.clone();
-        origins.sort_by(|a, b| b.offset.cmp(&a.offset));
+        origins.sort_by(|a, b| a.offset.cmp(&b.offset));
         let (offsets, unpadded_bytecode): (Vec<(usize, usize)>, Vec<Vec<u8>>) = origins
             .into_iter()
             .map(|origin| {
                 (
-                    (
-                        origin.offset,
-                        (origin.offset + origin.instructions.len() - 1),
-                    ),
+                    (origin.offset, (origin.offset + origin.instructions.len())),
                     origin.instructions,
                 )
             })
@@ -90,7 +87,7 @@ impl Emitter<Vec<u8>> for Vec<Origin<Vec<u8>>> {
                     .into_iter()
                     .map(|offset| *offset),
             )
-            .map(|(end_of_last, start_of_next)| start_of_next - end_of_last)
+            .map(|(start_of_next, end_of_last)| start_of_next - end_of_last)
             .chain(vec![0].into_iter())
             .collect::<Vec<usize>>();
 
@@ -98,10 +95,9 @@ impl Emitter<Vec<u8>> for Vec<Origin<Vec<u8>>> {
             .into_iter()
             .zip(padding)
             .map(|(bytecode, pad_size)| {
-                let normaized_pad_size = if pad_size > 0 { pad_size - 1 } else { 0 };
                 bytecode
                     .into_iter()
-                    .chain(vec![0 as u8].into_iter().cycle().take(normaized_pad_size))
+                    .chain(vec![0 as u8].into_iter().cycle().take(pad_size))
                     .collect::<Vec<u8>>()
             })
             .flatten()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub trait Emitter<T> {
 }
 
 /// Origin provides a structure for denoting memory offsets.
+#[derive(Debug, PartialEq)]
 pub struct Origin<T> {
     pub offset: usize,
     pub instructions: T,
@@ -65,7 +66,8 @@ pub trait Assembler<T> {
 // opcodes.
 pub fn assemble(backend: Backend, source: &str) -> AssemblerResult {
     let input: Vec<char> = source.chars().collect();
-    let tokens = preparser::PreParser::new().parse(&input).unwrap().unwrap();
+    let origin_tokens = preparser::PreParser::new().parse(&input).unwrap().unwrap();
+    let tokens = origin_tokens.instructions; // This will need to eventually be removed.
 
     match backend {
         Backend::MOS6502 => backends::mos6502::MOS6502Assembler::new().assemble(tokens),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,12 @@ pub trait Emitter<T> {
     fn emit(&self) -> T;
 }
 
+/// Origin provides a structure for denoting memory offsets.
+pub struct Origin<U> {
+    pub offset: usize,
+    pub instructions: U,
+}
+
 impl Emitter<Vec<u8>> for u8 {
     fn emit(&self) -> Vec<u8> {
         vec![*self]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -214,7 +214,6 @@ fn dec_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
     }
 }
 
-#[allow(dead_code)]
 pub fn decimal<'a>() -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
         Some(&next) if next.is_digit(10) => Ok(MatchStatus::Match((&input[1..], next))),

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -48,7 +48,6 @@ pub enum Token<T> {
 pub struct PreParser {}
 
 impl PreParser {
-    #[allow(dead_code)]
     pub fn new() -> Self {
         Self::default()
     }
@@ -68,8 +67,7 @@ impl<'a> Parser<'a, &'a [char], OriginStream> for PreParser {
     }
 }
 
-#[allow(dead_code)]
-pub fn origin_statements<'a>() -> impl parcel::Parser<'a, &'a [char], Origin<PreparseTokenStream>> {
+fn origin_statements<'a>() -> impl parcel::Parser<'a, &'a [char], Origin<PreparseTokenStream>> {
     right(join(
         zero_or_more(non_newline_whitespace().or(|| newline())),
         join(
@@ -85,8 +83,7 @@ pub fn origin_statements<'a>() -> impl parcel::Parser<'a, &'a [char], Origin<Pre
     .map(|(offset, statements)| Origin::with_offset(offset as usize, statements))
 }
 
-#[allow(dead_code)]
-pub fn statements<'a>() -> impl parcel::Parser<'a, &'a [char], PreparseTokenStream> {
+fn statements<'a>() -> impl parcel::Parser<'a, &'a [char], PreparseTokenStream> {
     one_or_more(statement()).map(|ioc| {
         ioc.into_iter()
             .filter(|oi| oi.is_some())
@@ -95,8 +92,7 @@ pub fn statements<'a>() -> impl parcel::Parser<'a, &'a [char], PreparseTokenStre
     })
 }
 
-#[allow(dead_code)]
-pub fn statement<'a>() -> impl parcel::Parser<'a, &'a [char], Option<Token<String>>> {
+fn statement<'a>() -> impl parcel::Parser<'a, &'a [char], Option<Token<String>>> {
     right(join(
         zero_or_more(non_newline_whitespace().or(|| newline())),
         left(join(
@@ -113,7 +109,6 @@ pub fn statement<'a>() -> impl parcel::Parser<'a, &'a [char], Option<Token<Strin
     ))
 }
 
-#[allow(dead_code)]
 fn instruction<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
     join(
         alphabetic(),

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -1,5 +1,5 @@
 extern crate parcel;
-use crate::Emitter;
+use crate::{Emitter, Origin};
 use parcel::parsers::character::*;
 use parcel::prelude::v1::*;
 use parcel::{join, left, one_of, one_or_more, optional, right, zero_or_more};
@@ -55,14 +55,16 @@ impl PreParser {
     }
 }
 
-impl<'a> Parser<'a, &'a [char], Vec<Token<String>>> for PreParser {
-    fn parse(&self, input: &'a [char]) -> ParseResult<'a, &'a [char], Vec<Token<String>>> {
-        statements().parse(input)
+type PreparseTokenStream = Vec<Token<String>>;
+
+impl<'a> Parser<'a, &'a [char], Origin<PreparseTokenStream>> for PreParser {
+    fn parse(&self, input: &'a [char]) -> ParseResult<'a, &'a [char], Origin<PreparseTokenStream>> {
+        statements().map(|tokens| Origin::new(tokens)).parse(input)
     }
 }
 
 #[allow(dead_code)]
-pub fn statements<'a>() -> impl parcel::Parser<'a, &'a [char], Vec<Token<String>>> {
+pub fn statements<'a>() -> impl parcel::Parser<'a, &'a [char], PreparseTokenStream> {
     one_or_more(statement()).map(|ioc| {
         ioc.into_iter()
             .filter(|oi| oi.is_some())

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -42,7 +42,7 @@ pub enum Token<T> {
     Instruction(T),
     Label(Label),
     Symbol((SymbolId, ByteValue)),
-    Offset(u32),
+    Origin(u32),
 }
 
 #[derive(Default)]
@@ -69,7 +69,7 @@ pub fn statement<'a>() -> impl parcel::Parser<'a, &'a [char], Vec<Token<String>>
             labeldef()
                 .map(|tok| Some(tok))
                 .or(|| symboldef().map(|tok| Some(tok)))
-                .or(|| orientation().map(|tok| Some(tok)))
+                .or(|| origin().map(|tok| Some(tok)))
                 .or(|| instruction().map(|tok| Some(tok)))
                 .or(|| comment().map(|_| None)),
             right(join(
@@ -174,14 +174,10 @@ fn four_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
     .map(|(s, v)| Token::Symbol((s.into_iter().collect(), ByteValue::Four(v))))
 }
 
-fn orientation<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
-    offset()
-}
-
-fn offset<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
+fn origin<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
     right(join(
-        join(expect_str(".offset"), one_or_more(non_newline_whitespace())),
+        join(expect_str(".origin"), one_or_more(non_newline_whitespace())),
         unsigned32(),
     ))
-    .map(|o| Token::Offset(o))
+    .map(|offset| Token::Origin(offset))
 }

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -57,13 +57,23 @@ impl PreParser {
 
 impl<'a> Parser<'a, &'a [char], Vec<Token<String>>> for PreParser {
     fn parse(&self, input: &'a [char]) -> ParseResult<'a, &'a [char], Vec<Token<String>>> {
-        statement().parse(input)
+        statements().parse(input)
     }
 }
 
 #[allow(dead_code)]
-pub fn statement<'a>() -> impl parcel::Parser<'a, &'a [char], Vec<Token<String>>> {
-    one_or_more(right(join(
+pub fn statements<'a>() -> impl parcel::Parser<'a, &'a [char], Vec<Token<String>>> {
+    one_or_more(statement()).map(|ioc| {
+        ioc.into_iter()
+            .filter(|oi| oi.is_some())
+            .map(|oi| oi.unwrap())
+            .collect()
+    })
+}
+
+#[allow(dead_code)]
+pub fn statement<'a>() -> impl parcel::Parser<'a, &'a [char], Option<Token<String>>> {
+    right(join(
         zero_or_more(non_newline_whitespace().or(|| newline())),
         left(join(
             labeldef()
@@ -77,13 +87,7 @@ pub fn statement<'a>() -> impl parcel::Parser<'a, &'a [char], Vec<Token<String>>
                 newline().or(|| eof()),
             )),
         )),
-    )))
-    .map(|ioc| {
-        ioc.into_iter()
-            .filter(|oi| oi.is_some())
-            .map(|oi| oi.unwrap())
-            .collect()
-    })
+    ))
 }
 
 #[allow(dead_code)]

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -89,15 +89,15 @@ fn should_parse_four_byte_constant() {
 
 #[test]
 fn should_parse_origin() {
-    let input = chars!(".origin 0x00001a2b\nnop");
+    let input = chars!("nop\n.origin 0x00001a2b\nnop");
 
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![crate::Origin::with_offset(
-                0x1a2b,
-                vec![Token::Instruction("nop".to_string())]
-            )]
+            vec![
+                crate::Origin::new(vec![Token::Instruction("nop".to_string())]),
+                crate::Origin::with_offset(0x1a2b, vec![Token::Instruction("nop".to_string())])
+            ]
         ))),
         PreParser::new().parse(&input)
     );

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -7,6 +7,12 @@ macro_rules! chars {
     };
 }
 
+macro_rules! zero_origin {
+    ($insts:expr) => {
+        $crate::Origin::new($insts)
+    };
+}
+
 #[test]
 fn should_parse_instruction_to_string() {
     let input = chars!("nop");
@@ -14,7 +20,7 @@ fn should_parse_instruction_to_string() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![Token::Instruction("nop".to_string())]
+            zero_origin!(vec![Token::Instruction("nop".to_string())])
         ))),
         PreParser::new().parse(&input)
     );
@@ -27,7 +33,7 @@ fn should_parse_label() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![Token::Label("test".to_string())]
+            zero_origin!(vec![Token::Label("test".to_string())])
         ))),
         PreParser::new().parse(&input)
     );
@@ -40,7 +46,10 @@ fn should_parse_single_byte_constant() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![Token::Symbol(("test".to_string(), ByteValue::One(255)))]
+            zero_origin!(vec![Token::Symbol((
+                "test".to_string(),
+                ByteValue::One(255)
+            ))])
         ))),
         PreParser::new().parse(&input)
     );
@@ -53,7 +62,10 @@ fn should_parse_two_byte_constant() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![Token::Symbol(("test".to_string(), ByteValue::Two(65535)))]
+            zero_origin!(vec![Token::Symbol((
+                "test".to_string(),
+                ByteValue::Two(65535)
+            ))])
         ))),
         PreParser::new().parse(&input)
     );
@@ -66,10 +78,10 @@ fn should_parse_four_byte_constant() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![Token::Symbol((
+            zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
                 ByteValue::Four(4294967295)
-            ))]
+            ))])
         ))),
         PreParser::new().parse(&input)
     );
@@ -82,7 +94,7 @@ fn should_parse_origin() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![Token::Origin(0x1a2b)]
+            zero_origin!(vec![Token::Origin(0x1a2b)])
         ))),
         PreParser::new().parse(&input)
     );

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -76,13 +76,13 @@ fn should_parse_four_byte_constant() {
 }
 
 #[test]
-fn should_parse_offset() {
-    let input = chars!(".offset 0x00001a2b");
+fn should_parse_origin() {
+    let input = chars!(".origin 0x00001a2b");
 
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![Token::Offset(0x00001a2b)]
+            vec![Token::Origin(0x1a2b)]
         ))),
         PreParser::new().parse(&input)
     );

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -20,7 +20,7 @@ fn should_parse_instruction_to_string() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            zero_origin!(vec![Token::Instruction("nop".to_string())])
+            vec![zero_origin!(vec![Token::Instruction("nop".to_string())])]
         ))),
         PreParser::new().parse(&input)
     );
@@ -33,7 +33,7 @@ fn should_parse_label() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            zero_origin!(vec![Token::Label("test".to_string())])
+            vec![zero_origin!(vec![Token::Label("test".to_string())])]
         ))),
         PreParser::new().parse(&input)
     );
@@ -46,10 +46,10 @@ fn should_parse_single_byte_constant() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            zero_origin!(vec![Token::Symbol((
+            vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
                 ByteValue::One(255)
-            ))])
+            ))])]
         ))),
         PreParser::new().parse(&input)
     );
@@ -62,10 +62,10 @@ fn should_parse_two_byte_constant() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            zero_origin!(vec![Token::Symbol((
+            vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
                 ByteValue::Two(65535)
-            ))])
+            ))])]
         ))),
         PreParser::new().parse(&input)
     );
@@ -78,10 +78,10 @@ fn should_parse_four_byte_constant() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            zero_origin!(vec![Token::Symbol((
+            vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
                 ByteValue::Four(4294967295)
-            ))])
+            ))])]
         ))),
         PreParser::new().parse(&input)
     );
@@ -89,12 +89,15 @@ fn should_parse_four_byte_constant() {
 
 #[test]
 fn should_parse_origin() {
-    let input = chars!(".origin 0x00001a2b");
+    let input = chars!(".origin 0x00001a2b\nnop");
 
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            zero_origin!(vec![Token::Origin(0x1a2b)])
+            vec![crate::Origin::with_offset(
+                0x1a2b,
+                vec![Token::Instruction("nop".to_string())]
+            )]
         ))),
         PreParser::new().parse(&input)
     );

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -139,7 +139,7 @@ init: ; test
 }
 
 #[test]
-fn should_pad_assembled_output() {
+fn should_pad_space_between_origins_in_assembled_output() {
     let input = "
 nop
 .origin 0x00000003

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -136,3 +136,20 @@ init: ; test
         assemble(Backend::MOS6502, input)
     )
 }
+
+#[test]
+fn should_parse_origins() {
+    let input = "
+nop
+.origin 0x0000000b
+nop
+";
+
+    assert_eq!(
+        Ok(vec![
+            crate::Origin::new(vec![0xea]),
+            crate::Origin::with_offset(11, vec![0xea])
+        ]),
+        assemble(Backend::MOS6502, input)
+    )
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -52,7 +52,7 @@ init:
 ";
 
     assert_eq!(
-        Err("label notinit, undefined at line: 6".to_string()),
+        Err("label notinit undefined".to_string()),
         assemble(Backend::MOS6502, input)
     )
 }
@@ -84,7 +84,7 @@ jmp 0x1234
 ";
 
     assert_eq!(
-        Err("symbol test, undefined at line: 2".to_string()),
+        Err("symbol test undefined".to_string()),
         assemble(Backend::MOS6502, input)
     )
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,8 +1,14 @@
 use crate::assemble;
 use crate::backends::Backend;
 
+macro_rules! zero_origin {
+    ($insts:expr) => {
+        $crate::Origin::new($insts)
+    };
+}
+
 #[test]
-fn should_generate_expected_opcode() {
+fn should_generate_expected_origin() {
     let input = "nop
 lda #0b00010010
 sta 4660
@@ -11,9 +17,9 @@ bpl *-16
 jmp 0x1234\n";
 
     assert_eq!(
-        Ok(vec![
+        Ok(vec![zero_origin!(vec![
             0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x10, 0x1a, 0x10, 0xf0, 0x4c, 0x34, 0x12
-        ]),
+        ])]),
         assemble(Backend::MOS6502, input)
     )
 }
@@ -32,9 +38,9 @@ init:
 ";
 
     assert_eq!(
-        Ok(vec![
+        Ok(vec![zero_origin!(vec![
             0xea, 0xa9, 0x12, 0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x03, 0x00
-        ]),
+        ])]),
         assemble(Backend::MOS6502, input)
     )
 }
@@ -69,7 +75,9 @@ jmp 0x1234
 ";
 
     assert_eq!(
-        Ok(vec![0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x34, 0x12]),
+        Ok(vec![zero_origin!(vec![
+            0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x34, 0x12
+        ])]),
         assemble(Backend::MOS6502, input)
     )
 }
@@ -102,7 +110,9 @@ init:
 ";
 
     assert_eq!(
-        Ok(vec![0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x00, 0x00]),
+        Ok(vec![zero_origin!(vec![
+            0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x00, 0x00
+        ])]),
         assemble(Backend::MOS6502, input)
     )
 }
@@ -120,7 +130,9 @@ init: ; test
 ";
 
     assert_eq!(
-        Ok(vec![0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x00, 0x00]),
+        Ok(vec![zero_origin!(vec![
+            0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x00, 0x00
+        ])]),
         assemble(Backend::MOS6502, input)
     )
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 use crate::assemble;
 use crate::backends::Backend;
+use crate::Emitter;
 
 macro_rules! zero_origin {
     ($insts:expr) => {
@@ -138,18 +139,17 @@ init: ; test
 }
 
 #[test]
-fn should_parse_origins() {
+fn should_pad_assembled_output() {
     let input = "
 nop
-.origin 0x0000000b
+.origin 0x00000003
+nop
+.origin 0x00000006
 nop
 ";
 
     assert_eq!(
-        Ok(vec![
-            crate::Origin::new(vec![0xea]),
-            crate::Origin::with_offset(11, vec![0xea])
-        ]),
-        assemble(Backend::MOS6502, input)
-    )
+        Ok(vec![0xea, 0x00, 0x00, 0xea, 0x00, 0x00, 0xea]),
+        assemble(Backend::MOS6502, input).map(|res| res.emit())
+    );
 }


### PR DESCRIPTION
# Introduction
This PR introduces the concept of origins which allow organization of instructions off of byte offsets.

```asm
.origin 0x8000
lda 0xff
sta A

.origin 0x00007ffc
.word 0x8000
```

## Example from tests
The below example shows the behavior 


```rust
#[test]
fn should_pad_assembled_output() {
    let input = "
nop
.origin 0x00000003
nop
.origin 0x00000006
nop
";

    assert_eq!(
        Ok(vec![0xea, 0x00, 0x00, 0xea, 0x00, 0x00, 0xea]),
        assemble(Backend::MOS6502, input).map(|res| res.emit())
    );
}
```

By introducing origin, padding and reset vector settings are no longer required as these can be directly set in the assembly file.

# Linked Issues
resolves #64 
#55 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented
  - should validate grammars are up to date.

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
