### PR TITLE
Add size constants to preparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,42 +15,48 @@ This feature-set is small to begin with but functions to standardize and consoli
 ### Grammar
 
 ```
-program        = ( whitespace | newline )* ( origin | statement )+ ;
+program         = ( whitespace | newline )* ( origin | statement )+ ;
 
-statements     = statement+ ;
+statements      = statement+ ;
 
-statement      = ( whitespace | newline )* ( labeldef | symboldef | instruction | comment ) comment?  ( newline | EOF );
+statement       = ( whitespace | newline )* ( labeldef | symboldef | constant | instruction | comment ) comment?  ( newline | EOF );
 
-instruction    = alphabetic ( alphabetic | digit | special | ";"! )+ ;
+instruction     = alphabetic ( alphabetic | digit | special | ";"! )+ ;
 
-comment        = ";" ( whitespace | character )* ;
+comment         = ";" ( whitespace | character )* ;
 
-symboldef      = bytedef | twobytedef | fourbytedef ;
+labeldef        = alphabetic* ":" ;
 
-bytedef        = ".1byte" whitespace+ alphabetic* whitespace+ byte ;
-twobytedef     = ".2byte" whitespace+ alphabetic* whitespace+ byte byte ;
-fourbytedef    = ".4byte" whitespace+ alphabetic* whitespace+ byte byte byte byte ;
+symboldef       = bytedef | worddef | doubleworddef ;
 
-origin         = ".origin" whitespace+ byte byte byte byte ;
+bytedef         = ".1byte" whitespace+ alphabetic* whitespace+ byte ;
+worddef         = ".2byte" whitespace+ alphabetic* whitespace+ byte byte ;
+doublworddef    = ".4byte" whitespace+ alphabetic* whitespace+ byte byte byte byte ;
 
-labeldef       = alphabetic* ":" ;
+origin          = ".origin" whitespace+ byte byte byte byte ;
 
-character      = lower|upper|digit|special ;
-whitespace     = " " | "\t" ;
-newline        = "\n" ;
-alphabetic     = (lower|upper) ;
-lower          = "a"|"b"|"c"|"d"|"e"|"f"|"g"|"h"|"i"|"j"|"k"|"l"|"m"
-               |"n"|"o"|"p"|"q"|"r"|"s"|"t"|"u"|"v"|"w"|"x"|"y"|"z" ;
-upper          = "A"|"B"|"C"|"D"|"E"|"F"|"G"|"H"|"I"|"J"|"K"|"L"|"M"
-               |"N"|"O"|"P"|"Q"|"R"|"S"|"T"|"U"|"V"|"W"|"X"|"Y"|"Z" ;
-byte           = ( "0x" hex hex ) | digit+ | ( "0b" binarybyte ) ;
-hex            = "0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"a"|"b"|"c"
-               |"d"|"e"|"f"|"A"|"B"|"C"|"D"|"E"|"F" ;
-binarybyte     = binary binary binary binary binary binary binary binary ;
-binary         = "0" | "1" ;
-digit          = "0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9" ;
-special        = "-"|"_"|"\""|"#"|"&"|"’"|"("|")"|"*"|"+"|","|"."|"/"
-               |":"|";"|"<"|"="|">" ;
+constant        = constbyte | constword constdoubleword ;
+
+constbyte       = ".byte" whitespace+ byte ;
+constword       = ".word" whitespace+ byte byte ;
+constdoubleword = ".doubleword" whitespace+ byte byte byte byte ;
+
+character       = lower|upper|digit|special ;
+whitespace      = " " | "\t" ;
+newline         = "\n" ;
+alphabetic      = (lower|upper) ;
+lower           = "a"|"b"|"c"|"d"|"e"|"f"|"g"|"h"|"i"|"j"|"k"|"l"|"m"
+                |"n"|"o"|"p"|"q"|"r"|"s"|"t"|"u"|"v"|"w"|"x"|"y"|"z" ;
+upper           = "A"|"B"|"C"|"D"|"E"|"F"|"G"|"H"|"I"|"J"|"K"|"L"|"M"
+                |"N"|"O"|"P"|"Q"|"R"|"S"|"T"|"U"|"V"|"W"|"X"|"Y"|"Z" ;
+byte            = ( "0x" hex hex ) | digit+ | ( "0b" binarybyte ) ;
+hex             = "0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"a"|"b"|"c"
+                |"d"|"e"|"f"|"A"|"B"|"C"|"D"|"E"|"F" ;
+binarybyte      = binary binary binary binary binary binary binary binary ;
+binary          = "0" | "1" ;
+digit           = "0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9" ;
+special         = "-"|"_"|"\""|"#"|"&"|"’"|"("|")"|"*"|"+"|","|"."|"/"
+                |":"|";"|"<"|"="|">" ;
 ```
 
 ## Backends

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -125,3 +125,24 @@ fn should_parse_constants() {
         PreParser::new().parse(&input)
     );
 }
+
+#[test]
+fn should_parse_constants_as_origin_statement() {
+    let input = chars!(
+        "
+.origin 0x00000003
+  .byte       0x1a
+"
+    );
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[input.len()..],
+            vec![crate::Origin::with_offset(
+                0x03,
+                vec![Token::Constant(ByteValue::Byte(0x1a)),]
+            ),]
+        ))),
+        PreParser::new().parse(&input)
+    );
+}

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -48,7 +48,7 @@ fn should_parse_single_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                ByteValue::One(255)
+                ByteValue::Byte(255)
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -64,7 +64,7 @@ fn should_parse_two_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                ByteValue::Two(65535)
+                ByteValue::Word(65535)
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -80,7 +80,7 @@ fn should_parse_four_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                ByteValue::Four(4294967295)
+                ByteValue::DoubleWord(4294967295)
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -98,6 +98,29 @@ fn should_parse_origin() {
                 crate::Origin::new(vec![Token::Instruction("nop".to_string())]),
                 crate::Origin::with_offset(0x1a2b, vec![Token::Instruction("nop".to_string())])
             ]
+        ))),
+        PreParser::new().parse(&input)
+    );
+}
+
+#[test]
+fn should_parse_constants() {
+    let input = chars!(
+        "
+.byte       0x1a
+.word       0x1a2b
+.doubleword 0x1a2b3c4d
+"
+    );
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[input.len()..],
+            vec![crate::Origin::new(vec![
+                Token::Constant(ByteValue::Byte(0x1a)),
+                Token::Constant(ByteValue::Word(0x1a2b)),
+                Token::Constant(ByteValue::DoubleWord(0x1a2b3c4d))
+            ]),]
         ))),
         PreParser::new().parse(&input)
     );

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -143,13 +143,30 @@ fn should_pad_space_between_origins_in_assembled_output() {
     let input = "
 nop
 .origin 0x00000003
-nop
+  nop
 .origin 0x00000006
-nop
+  nop
 ";
 
     assert_eq!(
         Ok(vec![0xea, 0x00, 0x00, 0xea, 0x00, 0x00, 0xea]),
+        assemble(Backend::MOS6502, input).map(|res| res.emit())
+    );
+}
+
+#[test]
+fn constants_should_emit_with_instructions() {
+    let input = "
+nop
+.origin 0x00000003
+  nop
+  .word 0x1a2b
+.origin 0x00000006
+  nop
+";
+
+    assert_eq!(
+        Ok(vec![0xea, 0x00, 0x00, 0xea, 0x2b, 0x1a, 0xea]),
         assemble(Backend::MOS6502, input).map(|res| res.emit())
     );
 }


### PR DESCRIPTION
# Introduction
This PR incorporates sized constants into the preparser which are extremely useful for things like, setting the reset vector or padding a file or offset. as can be seen by the following example:

```
.byte 0x00
.origin 0x00000003
  nop
  .doubleword 0x1a2b3c4d
.origin 0x00007ffc
  .word 0x0003
  .word 0x0000
```

# Linked Issues
resolves #64 
#63 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
