### PR TITLE
Refactor symbol definition syntax for consistency and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ labeldef        = alphabetic* ":" ;
 
 symboldef       = bytedef | worddef | doubleworddef ;
 
-bytedef         = ".1byte" whitespace+ alphabetic* whitespace+ byte ;
-worddef         = ".2byte" whitespace+ alphabetic* whitespace+ byte byte ;
-doublworddef    = ".4byte" whitespace+ alphabetic* whitespace+ byte byte byte byte ;
+bytedef         = ".define byte" whitespace+ alphabetic* whitespace+ byte ;
+worddef         = ".define word" whitespace+ alphabetic* whitespace+ byte byte ;
+doublworddef    = ".define doubleword" whitespace+ alphabetic* whitespace+ byte byte byte byte ;
 
 origin          = ".origin" whitespace+ byte byte byte byte ;
 

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -174,7 +174,10 @@ fn symboldef<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
 
 fn byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
     right(join(
-        join(expect_str(".1byte"), one_or_more(non_newline_whitespace())),
+        join(
+            expect_str(".define byte"),
+            one_or_more(non_newline_whitespace()),
+        ),
         join(
             left(join(
                 one_or_more(alphabetic()),
@@ -188,7 +191,10 @@ fn byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
 
 fn two_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
     right(join(
-        join(expect_str(".2byte"), one_or_more(non_newline_whitespace())),
+        join(
+            expect_str(".define word"),
+            one_or_more(non_newline_whitespace()),
+        ),
         join(
             left(join(
                 one_or_more(alphabetic()),
@@ -202,7 +208,10 @@ fn two_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
 
 fn four_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
     right(join(
-        join(expect_str(".4byte"), one_or_more(non_newline_whitespace())),
+        join(
+            expect_str(".define doubleword"),
+            one_or_more(non_newline_whitespace()),
+        ),
         join(
             left(join(
                 one_or_more(alphabetic()),

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -41,7 +41,7 @@ fn should_parse_label() {
 
 #[test]
 fn should_parse_single_byte_constant() {
-    let input = chars!(".1byte test 255");
+    let input = chars!(".define byte test 255");
 
     assert_eq!(
         Ok(MatchStatus::Match((
@@ -57,7 +57,7 @@ fn should_parse_single_byte_constant() {
 
 #[test]
 fn should_parse_two_byte_constant() {
-    let input = chars!(".2byte test 65535");
+    let input = chars!(".define word test 65535");
 
     assert_eq!(
         Ok(MatchStatus::Match((
@@ -73,7 +73,7 @@ fn should_parse_two_byte_constant() {
 
 #[test]
 fn should_parse_four_byte_constant() {
-    let input = chars!(".4byte test 4294967295");
+    let input = chars!(".define doubleword test 4294967295");
 
     assert_eq!(
         Ok(MatchStatus::Match((

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -67,7 +67,7 @@ init:
 #[test]
 fn should_generate_expected_opcodes_from_address_mode_symbols() {
     let input = "
-.1byte test 0x12
+.define byte test 0x12
 
 nop
 lda #test
@@ -101,7 +101,7 @@ jmp 0x1234
 #[test]
 fn should_differentate_between_label_and_symbol_definitions() {
     let input = "
-.1byte thisisatest 0x12
+.define byte thisisatest 0x12
 
 init:
     nop
@@ -121,7 +121,7 @@ init:
 #[test]
 fn should_ignore_comments_on_each_statement_type() {
     let input = "
-.1byte test 0x12 ; test
+.define byte test 0x12 ; test
 
 init: ; test
     nop ; test


### PR DESCRIPTION
# Introduction
This PR modifies the symbol definition syntax to match the following format `.define <size> <identifier> <value>` with an example being:

```asm
.define byte             test 0x00
.define word            test 0x0000
.define doubleword test 0x00000000
```

This adds a consistent prefix identifier as well as a brings the sizing keywords in line with other terminology in the preparser.

# Linked Issues
resolves #65 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
