### PR TITLE
Fix default argument handling of out-file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ source = "git+https://github.com/ncatelli/parcel?tag=v1.8.0#adcd04bec5b8bd7f09ef
 [[package]]
 name = "scrap"
 version = "0.1.0"
-source = "git+https://github.com/ncatelli/scrap?tag=v0.1.0#0e1b51915dd0df88d85cf75a6ae17a76dedf407f"
+source = "git+https://github.com/ncatelli/scrap?tag=v0.1.1#f47f11c636af40fb4c602df97c024ba594eb5d46"
 dependencies = [
  "parcel 1.5.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ lto = true
 
 [dependencies]
 parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.8.0" }
-scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.0" }
+scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.1" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,17 @@ fn main() {
         .description("An experimental 6502 assembler.")
         .author("Nate Catelli <ncatelli@packetfire.org>")
         .version("0.1.0")
+        .flag(
+            Flag::new()
+                .name("version")
+                .short_code("v")
+                .action(Action::StoreTrue)
+                .value_type(ValueType::Bool),
+        )
         .handler(Box::new(|c| {
-            println!("root dispatched with config: {:?}", c);
+            if Some(&Value::Bool(true)) == c.get("version") {
+                println!("0.1.0")
+            }
             Ok(0)
         }))
         .subcommand(


### PR DESCRIPTION
# Introduction
This pr fixes some default file argument behavior in the command line where out-file doesn't default to a.out if an `-o, --out-file` flag is not specified to the assemble subcommand.

```bash
$ ./target/debug/spasm assemble -i test.s && echo $?
0
```

Additionally, this includes a fix to not output the scrap configuration on an empty root command.

```bash
$ ./target/debug/spasm 
$ ./target/debug/spasm -v
0.1.0
```

# Linked Issues
resolves #71 
resolves #52 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
