### PR TITLE
Map unknown 6502 instructions to and error

### DIFF
--- a/src/backends/mos6502/instruction_set/mod.rs
+++ b/src/backends/mos6502/instruction_set/mod.rs
@@ -43,12 +43,12 @@ impl From<StaticInstruction> for Instruction {
 
 /// UnknownInstructionErr represents an Instruction that is unrepresentable or unknown.
 #[derive(Debug, Copy, Clone)]
-pub struct UnknownOpCodeErr {
+pub struct UnknownInstructionErr {
     mnemonic: Mnemonic,
     operand: AddressMode,
 }
 
-impl UnknownOpCodeErr {
+impl UnknownInstructionErr {
     pub fn new(mnemonic: Mnemonic, operand: AddressMode) -> Self {
         Self { mnemonic, operand }
     }
@@ -77,8 +77,8 @@ impl addressing::SizeOf for StaticInstruction {
     }
 }
 
-impl Emitter<Result<OpCode, UnknownOpCodeErr>> for StaticInstruction {
-    fn emit(&self) -> Result<OpCode, UnknownOpCodeErr> {
+impl Emitter<Result<OpCode, UnknownInstructionErr>> for StaticInstruction {
+    fn emit(&self) -> Result<OpCode, UnknownInstructionErr> {
         let mc = match (self.mnemonic, self.address_mode) {
             (Mnemonic::BRK, AddressMode::Implied) => 0x00,
             (Mnemonic::ORA, AddressMode::IndexedIndirect(_)) => 0x01,
@@ -235,16 +235,16 @@ impl Emitter<Result<OpCode, UnknownOpCodeErr>> for StaticInstruction {
         };
 
         if mc == 0xff {
-            Err(UnknownOpCodeErr::new(self.mnemonic, self.address_mode))
+            Err(UnknownInstructionErr::new(self.mnemonic, self.address_mode))
         } else {
             Ok(mc)
         }
     }
 }
 
-impl Emitter<Result<Vec<u8>, UnknownOpCodeErr>> for StaticInstruction {
-    fn emit(&self) -> Result<Vec<u8>, UnknownOpCodeErr> {
-        let opcode_res: Result<u8, UnknownOpCodeErr> = self.emit();
+impl Emitter<Result<Vec<u8>, UnknownInstructionErr>> for StaticInstruction {
+    fn emit(&self) -> Result<Vec<u8>, UnknownInstructionErr> {
+        let opcode_res: Result<u8, UnknownInstructionErr> = self.emit();
         let opcode = opcode_res?;
         let operand = self.address_mode.emit();
         Ok(vec![opcode].into_iter().chain(operand).collect())

--- a/src/backends/mos6502/instruction_set/mod.rs
+++ b/src/backends/mos6502/instruction_set/mod.rs
@@ -5,6 +5,7 @@ pub mod mnemonics;
 use crate::addressing;
 use crate::Emitter;
 pub use mnemonics::Mnemonic;
+use std::fmt;
 
 #[cfg(test)]
 mod tests;
@@ -51,6 +52,16 @@ pub struct UnknownInstructionErr {
 impl UnknownInstructionErr {
     pub fn new(mnemonic: Mnemonic, operand: AddressMode) -> Self {
         Self { mnemonic, operand }
+    }
+}
+
+impl fmt::Display for UnknownInstructionErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "unknown instruction: {:?} {:?}",
+            &self.mnemonic, &self.operand
+        )
     }
 }
 

--- a/src/backends/mos6502/instruction_set/tests/instructions.rs
+++ b/src/backends/mos6502/instruction_set/tests/instructions.rs
@@ -6,7 +6,8 @@ use crate::Emitter;
 #[test]
 fn instruction_with_accumulator_address_mode_should_return_single_byte() {
     let inst = StaticInstruction::new(Mnemonic::ASL, AddressMode::Accumulator);
-    let op: Vec<u8> = inst.emit();
+    let op_res: Result<Vec<u8>, _> = inst.emit();
+    let op: Vec<u8> = op_res.unwrap();
 
     assert_eq!(op, vec![0x0a])
 }
@@ -14,7 +15,8 @@ fn instruction_with_accumulator_address_mode_should_return_single_byte() {
 #[test]
 fn instruction_with_single_byte_operand_should_order_instructions_correctly() {
     let inst = StaticInstruction::new(Mnemonic::CPY, AddressMode::Immediate(0x12));
-    let op: Vec<u8> = inst.emit();
+    let op_res: Result<Vec<u8>, _> = inst.emit();
+    let op: Vec<u8> = op_res.unwrap();
 
     assert_eq!(op, vec![0xc0, 0x12])
 }
@@ -22,7 +24,8 @@ fn instruction_with_single_byte_operand_should_order_instructions_correctly() {
 #[test]
 fn instruction_with_two_byte_operand_should_order_operands_after_opcode_in_little_endian_format() {
     let inst = StaticInstruction::new(Mnemonic::CPY, AddressMode::Absolute(0x1234));
-    let op: Vec<u8> = inst.emit();
+    let op_res: Result<Vec<u8>, _> = inst.emit();
+    let op: Vec<u8> = op_res.unwrap();
 
     assert_eq!(op, vec![0xcc, 0x34, 0x12])
 }

--- a/src/backends/mos6502/instruction_set/tests/instructions.rs
+++ b/src/backends/mos6502/instruction_set/tests/instructions.rs
@@ -29,3 +29,11 @@ fn instruction_with_two_byte_operand_should_order_operands_after_opcode_in_littl
 
     assert_eq!(op, vec![0xcc, 0x34, 0x12])
 }
+
+#[test]
+fn unknown_instruction_should_thrown_an_error() {
+    let inst = StaticInstruction::new(Mnemonic::JMP, AddressMode::Accumulator);
+    let op_res: Result<Vec<u8>, _> = inst.emit();
+
+    assert!(op_res.is_err())
+}

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -234,14 +234,17 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins> for MOS6502As
                     .into_iter()
                     .map(|ioc| match ioc {
                         InstructionOrConstant::Instruction(si) => {
-                            let mc: Vec<u8> = si.emit();
+                            let mc: Result<Vec<u8>, _> = si.emit();
                             mc
                         }
                         InstructionOrConstant::Constant(v) => {
                             let mc: Vec<u8> = v.emit();
-                            mc
+                            Ok(mc)
                         }
                     })
+                    .collect::<Result<Vec<Vec<u8>>, _>>()
+                    .map_err(|e| format!("{:?}", e))?
+                    .into_iter()
                     .flatten()
                     .collect::<Vec<u8>>();
 

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -243,7 +243,7 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins> for MOS6502As
                         }
                     })
                     .collect::<Result<Vec<Vec<u8>>, _>>()
-                    .map_err(|e| format!("{:?}", e))?
+                    .map_err(|e| format!("{}", e))?
                     .into_iter()
                     .flatten()
                     .collect::<Vec<u8>>();


### PR DESCRIPTION
# Introduction
When an unknown instruction is encountered in the 6502 backend, assembly will now throw an error instead of failing silently and returning a `nop`.

# Linked Issues
resolves #61 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
