### PR TITLE
Constants accept references

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,23 @@ instruction     = alphabetic ( alphabetic | digit | special | ";"! )+ ;
 
 comment         = ";" ( whitespace | character )* ;
 
-labeldef        = alphabetic* ":" ;
+referenceid     = alphabetic* ;
+
+labeldef        = referenceid ":" ;
 
 symboldef       = bytedef | worddef | doubleworddef ;
 
-bytedef         = ".define byte" whitespace+ alphabetic* whitespace+ byte ;
-worddef         = ".define word" whitespace+ alphabetic* whitespace+ byte byte ;
-doublworddef    = ".define doubleword" whitespace+ alphabetic* whitespace+ byte byte byte byte ;
+bytedef         = ".define byte" whitespace+ referenceid whitespace+ byte ;
+worddef         = ".define word" whitespace+ referenceid whitespace+ byte byte ;
+doublworddef    = ".define doubleword" whitespace+ referenceid whitespace+ byte byte byte byte ;
 
 origin          = ".origin" whitespace+ byte byte byte byte ;
 
 constant        = constbyte | constword | constdoubleword ;
 
-constbyte       = ".byte" whitespace+ ( byte | label ) ;
-constword       = ".word" whitespace+ ( byte byte | label ) ;
-constdoubleword = ".doubleword" whitespace+ ( byte byte byte byte | label ) ;
+constbyte       = ".byte" whitespace+ ( byte | referenceid ) ;
+constword       = ".word" whitespace+ ( byte byte | referenceid ) ;
+constdoubleword = ".doubleword" whitespace+ ( byte byte byte byte | referenceid ) ;
 
 character       = lower|upper|digit|special ;
 whitespace      = " " | "\t" ;

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ doublworddef    = ".define doubleword" whitespace+ alphabetic* whitespace+ byte 
 
 origin          = ".origin" whitespace+ byte byte byte byte ;
 
-constant        = constbyte | constword constdoubleword ;
+constant        = constbyte | constword | constdoubleword ;
 
-constbyte       = ".byte" whitespace+ byte ;
-constword       = ".word" whitespace+ byte byte ;
-constdoubleword = ".doubleword" whitespace+ byte byte byte byte ;
+constbyte       = ".byte" whitespace+ ( byte | label ) ;
+constword       = ".word" whitespace+ ( byte byte | label ) ;
+constdoubleword = ".doubleword" whitespace+ ( byte byte byte byte | label ) ;
 
 character       = lower|upper|digit|special ;
 whitespace      = " " | "\t" ;

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -11,7 +11,7 @@ use crate::backends::mos6502::instruction_set::address_mode::{
     AddressMode, AddressModeOrReference,
 };
 use crate::backends::mos6502::instruction_set::{Instruction, StaticInstruction};
-use crate::preparser::{ByteValue, Token};
+use crate::preparser::{ByteValue, ByteValueOrLabel, Token};
 use crate::{Assembler, AssemblerResult};
 use crate::{Emitter, Origin};
 
@@ -51,13 +51,6 @@ impl From<Vec<SymbolTable>> for SymbolTable {
 
         Self::new(labels, symbols)
     }
-}
-
-/// ByteValueOrLabel represents a case where a value can be represented as
-/// either a static value or a reference.
-enum ByteValueOrLabel {
-    ByteValue(ByteValue),
-    Label(String),
 }
 
 /// Stores either an instruction or a constant value for assembling into a byte value

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -235,7 +235,7 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins> for MOS6502As
                                 ByteValueOrReference::ByteValue(bv) => Ok(bv),
                                 ByteValueOrReference::Reference(id) => symbol_table
                                     .labels
-                                    .get(&id).map(|&v| ByteValue::Word(v)).or(symbol_table
+                                    .get(&id).map(|&v| ByteValue::Word(v)).or_else(|| symbol_table
                                     .symbols
                                     .get(&id).map(|&v| ByteValue::Byte(v)))
                                     .ok_or(format!("reference {} undefined", &id))

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -131,10 +131,8 @@ fn generate_symbol_table_from_instructions_origin(
                     insts.push(InstructionOrConstant::Instruction(i));
                     (st, insts)
                 }
-                Token::Constant(v) => {
-                    insts.push(InstructionOrConstant::Constant(
-                        ByteValueOrLabel::ByteValue(v),
-                    ));
+                Token::Constant(bvol) => {
+                    insts.push(InstructionOrConstant::Constant(bvol));
                     (st, insts)
                 }
                 Token::Label(l) => {

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -46,6 +46,13 @@ impl SizeOf for ByteValue {
     }
 }
 
+/// ByteValueOrLabel represents a case where a value can be represented as
+/// either a static value or a reference.
+pub enum ByteValueOrLabel {
+    ByteValue(ByteValue),
+    Label(String),
+}
+
 /// Token wraps the token variants that can be derived from the
 /// parser.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -46,12 +46,12 @@ impl SizeOf for ByteValue {
     }
 }
 
-/// ByteValueOrLabel represents a case where a value can be represented as
+/// ByteValueOrReference represents a case where a value can be represented as
 /// either a static value or a reference.
 #[derive(Debug, Clone, PartialEq)]
-pub enum ByteValueOrLabel {
+pub enum ByteValueOrReference {
     ByteValue(ByteValue),
-    Label(String),
+    Reference(String),
 }
 
 /// Token wraps the token variants that can be derived from the
@@ -61,7 +61,7 @@ pub enum Token<T> {
     Instruction(T),
     Label(Label),
     Symbol((SymbolId, ByteValue)),
-    Constant(ByteValueOrLabel),
+    Constant(ByteValueOrReference),
 }
 
 #[derive(Default)]
@@ -250,41 +250,41 @@ fn constant<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
         .map(Token::Constant)
 }
 
-fn const_byte<'a>() -> impl parcel::Parser<'a, &'a [char], ByteValueOrLabel> {
+fn const_byte<'a>() -> impl parcel::Parser<'a, &'a [char], ByteValueOrReference> {
     right(join(
         join(expect_str(".byte"), one_or_more(non_newline_whitespace())),
         unsigned8()
-            .map(|b| ByteValueOrLabel::ByteValue(ByteValue::Byte(b)))
+            .map(|b| ByteValueOrReference::ByteValue(ByteValue::Byte(b)))
             .or(|| {
                 one_or_more(alphabetic())
-                    .map(|vc| ByteValueOrLabel::Label(vc.into_iter().collect()))
+                    .map(|vc| ByteValueOrReference::Reference(vc.into_iter().collect()))
             }),
     ))
 }
 
-fn const_word<'a>() -> impl parcel::Parser<'a, &'a [char], ByteValueOrLabel> {
+fn const_word<'a>() -> impl parcel::Parser<'a, &'a [char], ByteValueOrReference> {
     right(join(
         join(expect_str(".word"), one_or_more(non_newline_whitespace())),
         unsigned16()
-            .map(|w| ByteValueOrLabel::ByteValue(ByteValue::Word(w)))
+            .map(|w| ByteValueOrReference::ByteValue(ByteValue::Word(w)))
             .or(|| {
                 one_or_more(alphabetic())
-                    .map(|vc| ByteValueOrLabel::Label(vc.into_iter().collect()))
+                    .map(|vc| ByteValueOrReference::Reference(vc.into_iter().collect()))
             }),
     ))
 }
 
-fn const_doubleword<'a>() -> impl parcel::Parser<'a, &'a [char], ByteValueOrLabel> {
+fn const_doubleword<'a>() -> impl parcel::Parser<'a, &'a [char], ByteValueOrReference> {
     right(join(
         join(
             expect_str(".doubleword"),
             one_or_more(non_newline_whitespace()),
         ),
         unsigned32()
-            .map(|dw| ByteValueOrLabel::ByteValue(ByteValue::DoubleWord(dw)))
+            .map(|dw| ByteValueOrReference::ByteValue(ByteValue::DoubleWord(dw)))
             .or(|| {
                 one_or_more(alphabetic())
-                    .map(|vc| ByteValueOrLabel::Label(vc.into_iter().collect()))
+                    .map(|vc| ByteValueOrReference::Reference(vc.into_iter().collect()))
             }),
     ))
 }

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::preparser::{ByteValue, PreParser, Token};
+use crate::preparser::{ByteValue, ByteValueOrLabel, PreParser, Token};
 use parcel::prelude::v1::*;
 
 macro_rules! chars {
@@ -117,9 +117,11 @@ fn should_parse_constants() {
         Ok(MatchStatus::Match((
             &input[input.len()..],
             vec![crate::Origin::new(vec![
-                Token::Constant(ByteValue::Byte(0x1a)),
-                Token::Constant(ByteValue::Word(0x1a2b)),
-                Token::Constant(ByteValue::DoubleWord(0x1a2b3c4d))
+                Token::Constant(ByteValueOrLabel::ByteValue(ByteValue::Byte(0x1a))),
+                Token::Constant(ByteValueOrLabel::ByteValue(ByteValue::Word(0x1a2b))),
+                Token::Constant(ByteValueOrLabel::ByteValue(ByteValue::DoubleWord(
+                    0x1a2b3c4d
+                )))
             ]),]
         ))),
         PreParser::new().parse(&input)
@@ -140,7 +142,9 @@ fn should_parse_constants_as_origin_statement() {
             &input[input.len()..],
             vec![crate::Origin::with_offset(
                 0x03,
-                vec![Token::Constant(ByteValue::Byte(0x1a)),]
+                vec![Token::Constant(ByteValueOrLabel::ByteValue(
+                    ByteValue::Byte(0x1a)
+                )),]
             ),]
         ))),
         PreParser::new().parse(&input)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -170,3 +170,18 @@ nop
         assemble(Backend::MOS6502, input).map(|res| res.emit())
     );
 }
+
+#[test]
+fn constants_should_correctly_dereference_labels() {
+    let input = "
+nop
+init:
+  nop
+  .word init
+";
+
+    assert_eq!(
+        Ok(vec![0xea, 0xea, 0x01, 0x00]),
+        assemble(Backend::MOS6502, input).map(|res| res.emit())
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -172,16 +172,18 @@ nop
 }
 
 #[test]
-fn constants_should_correctly_dereference_labels() {
+fn constants_should_correctly_dereference_references() {
     let input = "
+.define byte test 0xff
 nop
 init:
   nop
   .word init
+  .byte test
 ";
 
     assert_eq!(
-        Ok(vec![0xea, 0xea, 0x01, 0x00]),
+        Ok(vec![0xea, 0xea, 0x01, 0x00, 0xff]),
         assemble(Backend::MOS6502, input).map(|res| res.emit())
     );
 }


### PR DESCRIPTION
# Introduction
This PR is the first pass at enabling symbol references as arguments to sized constant definitions.

```
.define byte test 0xff
nop

.origin 0x0000000a
init:
  nop
  nop
  nop

.origin 0x0000001a
  .word init 
  .byte test
```

```
$ xxd a.out 
00000000: ea00 0000 0000 0000 0000 eaea ea00 0000  ................
00000010: 0000 0000 0000 0000 0000 0a00 ff         .............
```

# Linked Issues
resolves #69 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
