### PR TITLE
Add BackendErr type

### DIFF
--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -3,6 +3,21 @@ use std::convert::TryFrom;
 #[macro_use]
 pub mod mos6502;
 
+/// Error type returned from backends.
+pub enum BackendErr {
+    ParseError(String),
+}
+
+impl std::fmt::Display for BackendErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let output = match self {
+            BackendErr::ParseError(input) => format!("unable to parse: {}", input),
+        };
+
+        write!(f, "{}", output)
+    }
+}
+
 /// Backend represents the backend targets currently supported by spasm.
 #[derive(Debug)]
 pub enum Backend {

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -4,14 +4,21 @@ use std::convert::TryFrom;
 pub mod mos6502;
 
 /// Error type returned from backends.
+#[allow(dead_code)]
 pub enum BackendErr {
-    ParseError(String),
+    Parse(String),
+    UndefinedReference(String),
+    UndefinedInstruction(String),
+    Unspecified(String),
 }
 
 impl std::fmt::Display for BackendErr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let output = match self {
-            BackendErr::ParseError(input) => format!("unable to parse: {}", input),
+            Self::Parse(input) => input.clone(),
+            Self::UndefinedReference(input) => format!("reference undefined: {}", input),
+            Self::UndefinedInstruction(input) => input.clone(),
+            Self::Unspecified(input) => input.clone(),
         };
 
         write!(f, "{}", output)

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -91,7 +91,7 @@ fn parse_string_instructions_origin_to_token_instructions_origin(
 
 fn convert_token_instructions_origins_to_positional_tokens_origin(
     source: Origin<Token6502InstStream>,
-) -> Result<Origin<PositionalToken6502Stream>, String> {
+) -> Result<Origin<PositionalToken6502Stream>, BackendErr> {
     let origin_offset = source.offset;
     let tokens = source.instructions;
     let positional_instructions = tokens
@@ -120,7 +120,7 @@ fn convert_token_instructions_origins_to_positional_tokens_origin(
 
 fn generate_symbol_table_from_instructions_origin(
     source: Origin<PositionalToken6502Stream>,
-) -> Result<(SymbolTable, Origin<MemoryAligned6502Stream>), String> {
+) -> Result<(SymbolTable, Origin<MemoryAligned6502Stream>), BackendErr> {
     let (origin_offset, instructions) = source.into();
     let (symbol_table, tokens) = instructions.into_iter().fold(
         (SymbolTable::default(), Vec::new()),
@@ -158,7 +158,7 @@ fn generate_symbol_table_from_instructions_origin(
 fn dereference_instructions_to_static_instructions(
     symbol_table: &SymbolTable,
     src_ioc: InstructionOrConstant<Instruction, ByteValueOrReference>,
-) -> Result<InstructionOrConstant<StaticInstruction, ByteValue>, String> {
+) -> Result<InstructionOrConstant<StaticInstruction, ByteValue>, BackendErr> {
     match src_ioc {
         InstructionOrConstant::Instruction(i) => {
             let mnemonic = i.mnemonic;
@@ -167,11 +167,11 @@ fn dereference_instructions_to_static_instructions(
                 AddressModeOrReference::Label(l) => symbol_table
                     .labels
                     .get(&l)
-                    .map_or(Err(format!("label {} undefined", &l)), |offset| {
+                    .map_or(Err(BackendErr::UndefinedReference(l.clone())), |offset| {
                         Ok((mnemonic, AddressMode::Absolute(*offset)))
                     }),
                 AddressModeOrReference::Symbol(s) => symbol_table.symbols.get(&s.symbol).map_or(
-                    Err(format!("symbol {} undefined", &s.symbol)),
+                    Err(BackendErr::UndefinedReference(s.symbol.clone())),
                     |byte_value| Ok((mnemonic, AddressMode::Immediate(*byte_value))),
                 ),
                 AddressModeOrReference::AddressMode(am) => Ok((mnemonic, am)),
@@ -185,7 +185,7 @@ fn dereference_instructions_to_static_instructions(
                 .get(&id)
                 .map(|&v| ByteValue::Word(v))
                 .or_else(|| symbol_table.symbols.get(&id).map(|&v| ByteValue::Byte(v)))
-                .ok_or(format!("reference {} undefined", &id)),
+                .ok_or_else(|| BackendErr::UndefinedReference(id.clone())),
         }
         .map(InstructionOrConstant::Constant),
     }
@@ -202,20 +202,22 @@ impl MOS6502Assembler {
     }
 }
 
-impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, String> for MOS6502Assembler {
+impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
+    for MOS6502Assembler
+{
     fn assemble(
         &self,
         source: Vec<Origin<UnparsedTokenStream>>,
-    ) -> AssemblerResult<AssembledOrigins, String> {
+    ) -> AssemblerResult<AssembledOrigins, BackendErr> {
         let token_instructions: Vec<Origin<Token6502InstStream>> = source
             .into_iter()
             .map(parse_string_instructions_origin_to_token_instructions_origin)
             .collect::<Result<Vec<Origin<Token6502InstStream>>, parser::ParseErr>>()
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| BackendErr::Parse(e.to_string()))?;
         let positional_tokens: Vec<Origin<PositionalToken6502Stream>> = token_instructions
             .into_iter()
             .map(convert_token_instructions_origins_to_positional_tokens_origin)
-            .collect::<Result<Vec<Origin<PositionalToken6502Stream>>, String>>()?;
+            .collect::<Result<Vec<Origin<PositionalToken6502Stream>>, BackendErr>>()?;
 
         // Collect the symbols and instructions into a vector with each item
         // representing an origins contents
@@ -225,7 +227,7 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, String> for M
         ) = positional_tokens
             .into_iter()
             .map(generate_symbol_table_from_instructions_origin)
-            .collect::<Result<Vec<(SymbolTable, Origin<MemoryAligned6502Stream>)>, String>>()?
+            .collect::<Result<Vec<(SymbolTable, Origin<MemoryAligned6502Stream>)>, BackendErr>>()?
             .into_iter()
             .unzip();
 
@@ -239,36 +241,34 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, String> for M
                 let instructions = origin.instructions;
 
                 let assembled_instructions =
-                        instructions
-                            .into_iter()
-                            .map(|ioc| (&symbol_table, ioc))
-                            .map(|(st, ioc)| {
-                                dereference_instructions_to_static_instructions(st, ioc)
-                            })
-                            .collect::<Result<
-                                Vec<InstructionOrConstant<StaticInstruction, ByteValue>>,
-                                String,
-                            >>()?
-                            .into_iter()
-                            .map(|ioc| match ioc {
-                                InstructionOrConstant::Instruction(si) => {
-                                    let mc: Result<Vec<u8>, _> = si.emit();
-                                    mc
-                                }
-                                InstructionOrConstant::Constant(v) => {
-                                    let mc: Vec<u8> = v.emit();
-                                    Ok(mc)
-                                }
-                            })
-                            .collect::<Result<Vec<Vec<u8>>, _>>()
-                            .map_err(|e| format!("{}", e))?
-                            .into_iter()
-                            .flatten()
-                            .collect::<Vec<u8>>();
+                    instructions
+                        .into_iter()
+                        .map(|ioc| (&symbol_table, ioc))
+                        .map(|(st, ioc)| dereference_instructions_to_static_instructions(st, ioc))
+                        .collect::<Result<
+                            Vec<InstructionOrConstant<StaticInstruction, ByteValue>>,
+                            BackendErr,
+                        >>()?
+                        .into_iter()
+                        .map(|ioc| match ioc {
+                            InstructionOrConstant::Instruction(si) => {
+                                let mc: Result<Vec<u8>, _> = si.emit();
+                                mc
+                            }
+                            InstructionOrConstant::Constant(v) => {
+                                let mc: Vec<u8> = v.emit();
+                                Ok(mc)
+                            }
+                        })
+                        .collect::<Result<Vec<Vec<u8>>, _>>()
+                        .map_err(|e| BackendErr::UndefinedInstruction(e.to_string()))?
+                        .into_iter()
+                        .flatten()
+                        .collect::<Vec<u8>>();
 
                 Ok(Origin::with_offset(origin_offset, assembled_instructions))
             })
-            .collect::<Result<Vec<Origin<Vec<u8>>>, String>>()?;
+            .collect::<Result<Vec<Origin<Vec<u8>>>, BackendErr>>()?;
 
         Ok(opcode_origins)
     }

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -202,11 +202,11 @@ impl MOS6502Assembler {
     }
 }
 
-impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins> for MOS6502Assembler {
+impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, String> for MOS6502Assembler {
     fn assemble(
         &self,
         source: Vec<Origin<UnparsedTokenStream>>,
-    ) -> AssemblerResult<AssembledOrigins> {
+    ) -> AssemblerResult<AssembledOrigins, String> {
         let token_instructions: Vec<Origin<Token6502InstStream>> = source
             .into_iter()
             .map(parse_string_instructions_origin_to_token_instructions_origin)

--- a/src/backends/mos6502/parser/mod.rs
+++ b/src/backends/mos6502/parser/mod.rs
@@ -15,6 +15,7 @@ use crate::parser::*;
 mod tests;
 
 /// Error type returned from backends.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum ParseErr {
     Unmatched(String),

--- a/src/backends/mos6502/parser/mod.rs
+++ b/src/backends/mos6502/parser/mod.rs
@@ -14,6 +14,24 @@ use crate::parser::*;
 #[cfg(test)]
 mod tests;
 
+/// Error type returned from backends.
+#[derive(Debug, Clone)]
+pub enum ParseErr {
+    Unmatched(String),
+    Unspecified(String),
+}
+
+impl std::fmt::Display for ParseErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let output = match self {
+            ParseErr::Unmatched(input) => format!("unable to parse expected tokens: {}", input),
+            ParseErr::Unspecified(input) => format!("unspecified parse error: {}", input),
+        };
+
+        write!(f, "{}", output)
+    }
+}
+
 pub fn instruction<'a>() -> impl parcel::Parser<'a, &'a [char], Instruction> {
     join(
         right(join(zero_or_more(non_newline_whitespace()), mnemonic())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,18 +105,18 @@ type AssembledOrigins = Vec<Origin<Vec<u8>>>;
 
 /// A type storing the results of an assemble representing an array of bytes
 /// or a String Error.
-pub type AssemblerResult<U> = Result<U, String>;
+pub type AssemblerResult<U, E> = Result<U, E>;
 
 /// The Assembler trait takes in an arbitrary length str, assembling it against
 // a target and returning a result containing either the assembled bytecode or
 // an error.
-pub trait Assembler<T, U> {
-    fn assemble(&self, source: T) -> AssemblerResult<U>;
+pub trait Assembler<T, U, E> {
+    fn assemble(&self, source: T) -> AssemblerResult<U, E>;
 }
 
 // Converts a source string to it's corresponding array of little endinan binary
 // opcodes.
-pub fn assemble(backend: Backend, source: &str) -> AssemblerResult<AssembledOrigins> {
+pub fn assemble(backend: Backend, source: &str) -> AssemblerResult<AssembledOrigins, String> {
     let input: Vec<char> = source.chars().collect();
     let origin_tokens = preparser::PreParser::new().parse(&input).unwrap().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,4 +123,5 @@ pub fn assemble(backend: Backend, source: &str) -> AssemblerResult<AssembledOrig
     match backend {
         Backend::MOS6502 => backends::mos6502::MOS6502Assembler::new().assemble(origin_tokens),
     }
+    .map_err(|e| e.to_string())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub type AssemblerResult<U, E> = Result<U, E>;
 /// The Assembler trait takes in an arbitrary length str, assembling it against
 // a target and returning a result containing either the assembled bytecode or
 // an error.
-pub trait Assembler<T, U, E> {
+pub trait Assembler<T, U, E: std::fmt::Display> {
     fn assemble(&self, source: T) -> AssemblerResult<U, E>;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ impl fmt::Display for RuntimeError {
 }
 
 fn main() {
-    let args: Vec<String> = env::args().into_iter().collect();
+    let args: Vec<String> = env::args().collect();
 
     let res = Cmd::new()
         .name("spasm")

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -59,7 +59,7 @@ init:
 ";
 
     assert_eq!(
-        Err("label notinit undefined".to_string()),
+        Err("reference undefined: notinit".to_string()),
         assemble(Backend::MOS6502, input)
     )
 }
@@ -93,7 +93,7 @@ jmp 0x1234
 ";
 
     assert_eq!(
-        Err("symbol test undefined".to_string()),
+        Err("reference undefined: test".to_string()),
         assemble(Backend::MOS6502, input)
     )
 }


### PR DESCRIPTION
# Introduction
This PR starts the process of removing string err responses with a dedicated error type that can be better refined.
# Linked Issues
#41 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
