### PR TITLE
Update hex parser to not require leading zero for sized input

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bytedef         = ".define byte" whitespace+ referenceid whitespace+ byte ;
 worddef         = ".define word" whitespace+ referenceid whitespace+ byte byte ;
 doublworddef    = ".define doubleword" whitespace+ referenceid whitespace+ byte byte byte byte ;
 
-origin          = ".origin" whitespace+ byte byte byte byte ;
+origin          = ".origin" whitespace+ byte (byte (byte byte?)?)? ;
 
 constant        = constbyte | constword | constdoubleword ;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,7 +2,10 @@ extern crate parcel;
 use parcel::parsers::character::{expect_character, expect_str};
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;
-use parcel::{join, one_or_more, optional, right, take_n};
+use parcel::{join, one_or_more, optional, right, take_n, take_until_n};
+
+#[cfg(test)]
+mod tests;
 
 macro_rules! char_vec_to_u32_from_radix {
     ($chars:expr, $radix:expr) => {
@@ -98,7 +101,7 @@ fn hex_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
 }
 
 pub fn hex_bytes<'a>(bytes: usize) -> impl Parser<'a, &'a [char], Vec<char>> {
-    take_n(hex_digit(), bytes * 2)
+    take_until_n(hex_digit(), bytes * 2)
 }
 
 pub fn hex_digit<'a>() -> impl Parser<'a, &'a [char], char> {

--- a/src/parser/tests/mod.rs
+++ b/src/parser/tests/mod.rs
@@ -1,0 +1,26 @@
+extern crate parcel;
+use crate::parser::{hex_u16, hex_u32, hex_u8};
+use parcel::prelude::v1::*;
+
+#[test]
+fn should_parse_a_matching_u8_hex_value_into_any_encompassing_unsigned_integer() {
+    let input: Vec<char> = "0xFF".chars().collect();
+
+    // u8
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[4..], 0xff))),
+        hex_u8().parse(&input)
+    );
+
+    // u16
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[4..], 0xff))),
+        hex_u16().parse(&input)
+    );
+
+    // u32
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[4..], 0xff))),
+        hex_u32().parse(&input)
+    );
+}

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -132,7 +132,7 @@ fn should_parse_constants() {
 fn should_parse_constants_as_origin_statement() {
     let input = chars!(
         "
-.origin 0x00000003
+.origin 0x03
   .byte       0x1a
 "
     );
@@ -157,7 +157,7 @@ fn should_parse_labels_as_constant_arguments() {
         "
 .define byte test 0xff
 init:
-.origin 0x00000003
+.origin 0x03
   .word       init
   .byte       test
 "

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -142,9 +142,9 @@ init: ; test
 fn should_pad_space_between_origins_in_assembled_output() {
     let input = "
 nop
-.origin 0x00000003
+.origin 0x03
   nop
-.origin 0x00000006
+.origin 0x06
   nop
 ";
 
@@ -158,10 +158,10 @@ nop
 fn constants_should_emit_with_instructions() {
     let input = "
 nop
-.origin 0x00000003
+.origin 0x03
   nop
   .word 0x1a2b
-.origin 0x00000006
+.origin 0x06
   nop
 ";
 


### PR DESCRIPTION
# Introduction
This PR updates hex_bytes to nolonger require leading zeroes for sized input. This is handy for examples like the following:

```
.origin 0x00008000
  nop
```

The above includes a 32bit offset and thus requires 4 leading values for an offset that would fit into a 16 bit address space. After the change included in this PR this can now be specified as

```
.origin 0x8000
  nop
```

# Linked Issues
resolves #84 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
