### PR TITLE
Add additional refinement to hex digit parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ source = "git+https://github.com/ncatelli/parcel?tag=v1.6.0#6c01cf75438cbf2fd55c
 [[package]]
 name = "parcel"
 version = "1.8.0"
-source = "git+https://github.com/ncatelli/parcel?tag=v1.8.0#adcd04bec5b8bd7f09efe35c4a5d88b6a7df3928"
+source = "git+https://github.com/ncatelli/parcel?tag=v1.9.0#6a0e222fbbc3b96032d02c6bd1c2b9529f6ab4c1"
 
 [[package]]
 name = "scrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 lto = true
 
 [dependencies]
-parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.8.0" }
+parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.9.0" }
 scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.1" }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -84,6 +84,7 @@ fn sign<'a>() -> impl Parser<'a, &'a [char], Sign> {
         })
 }
 
+#[allow(clippy::clippy::redundant_closure)]
 fn hex_u32<'a>() -> impl Parser<'a, &'a [char], u32> {
     right(join(
         expect_str("0x"),
@@ -92,6 +93,7 @@ fn hex_u32<'a>() -> impl Parser<'a, &'a [char], u32> {
     .map(|hex| char_vec_to_u32_from_radix!(hex, 16))
 }
 
+#[allow(clippy::clippy::redundant_closure)]
 fn hex_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
     right(join(
         expect_str("0x"),
@@ -100,6 +102,7 @@ fn hex_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
     .map(|hex| char_vec_to_u16_from_radix!(hex, 16))
 }
 
+#[allow(clippy::clippy::redundant_closure)]
 fn hex_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
     right(join(
         expect_str("0x"),
@@ -108,6 +111,7 @@ fn hex_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
     .map(|hex| char_vec_to_u8_from_radix!(hex, 16))
 }
 
+#[allow(clippy::clippy::redundant_closure)]
 fn hex_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
     right(join(
         expect_str("0x"),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,5 @@
 extern crate parcel;
-use parcel::parsers::character::{expect_character, expect_str};
+use parcel::parsers::character::{eof, expect_character, expect_str, whitespace};
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;
 use parcel::{join, one_or_more, optional, right, take_n, take_until_n};
@@ -85,19 +85,35 @@ fn sign<'a>() -> impl Parser<'a, &'a [char], Sign> {
 }
 
 fn hex_u32<'a>() -> impl Parser<'a, &'a [char], u32> {
-    right(join(expect_str("0x"), hex_bytes(4))).map(|hex| char_vec_to_u32_from_radix!(hex, 16))
+    right(join(
+        expect_str("0x"),
+        hex_bytes(4).peek_next(special_character().or(|| whitespace().or(|| eof()))),
+    ))
+    .map(|hex| char_vec_to_u32_from_radix!(hex, 16))
 }
 
 fn hex_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
-    right(join(expect_str("0x"), hex_bytes(2))).map(|hex| char_vec_to_u16_from_radix!(hex, 16))
+    right(join(
+        expect_str("0x"),
+        hex_bytes(2).peek_next(special_character().or(|| whitespace().or(|| eof()))),
+    ))
+    .map(|hex| char_vec_to_u16_from_radix!(hex, 16))
 }
 
 fn hex_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
-    right(join(expect_str("0x"), hex_bytes(1))).map(|hex| char_vec_to_u8_from_radix!(hex, 16))
+    right(join(
+        expect_str("0x"),
+        hex_bytes(1).peek_next(special_character().or(|| whitespace().or(|| eof()))),
+    ))
+    .map(|hex| char_vec_to_u8_from_radix!(hex, 16))
 }
 
 fn hex_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
-    right(join(expect_str("0x"), hex_bytes(1))).map(|hex| char_vec_to_i8_from_radix!(hex, 16))
+    right(join(
+        expect_str("0x"),
+        hex_bytes(1).peek_next(special_character().or(|| whitespace().or(|| eof()))),
+    ))
+    .map(|hex| char_vec_to_i8_from_radix!(hex, 16))
 }
 
 pub fn hex_bytes<'a>(bytes: usize) -> impl Parser<'a, &'a [char], Vec<char>> {
@@ -225,6 +241,17 @@ fn dec_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
 pub fn decimal<'a>() -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
         Some(&next) if next.is_digit(10) => Ok(MatchStatus::Match((&input[1..], next))),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+pub fn special_character<'a>() -> impl Parser<'a, &'a [char], char> {
+    let special = vec![
+        '-', '_', '\\', '|', '#', '&', '’', '(', ')', '*', '+', ',', '.', '/', ':', ';', '<', '=',
+        '>',
+    ];
+    move |input: &'a [char]| match input.get(0) {
+        Some(&next) if special.contains(&next) => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),
     }
 }


### PR DESCRIPTION
# Introduction
This PR bumps the version of parcel to `v1.9.0` to take advantage of the `peek_next` combinator. This is used to ensure that a hex digit does not exceed the bounds that are expected by validating that the next value is either a special character, whitespace or an EOF.

# Linked Issues
#84 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
