### PR TITLE
Remove extern crate references

### DIFF
--- a/src/backends/mos6502/parser/mod.rs
+++ b/src/backends/mos6502/parser/mod.rs
@@ -1,4 +1,3 @@
-extern crate parcel;
 use crate::backends::mos6502::instruction_set::address_mode::{
     AddressMode, AddressModeOrReference, AddressModeType, Symbol,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-extern crate scrap;
 use scrap::prelude::v1::*;
 use spasm::assemble;
 use spasm::Backend;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,3 @@
-extern crate parcel;
 use parcel::parsers::character::{eof, expect_character, expect_str, whitespace};
 use parcel::prelude::v1::*;
 use parcel::MatchStatus;

--- a/src/parser/tests/mod.rs
+++ b/src/parser/tests/mod.rs
@@ -1,4 +1,3 @@
-extern crate parcel;
 use crate::parser::{hex_u16, hex_u32, hex_u8};
 use parcel::prelude::v1::*;
 

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -1,4 +1,3 @@
-extern crate parcel;
 use crate::addressing::SizeOf;
 use crate::{Emitter, Origin};
 use parcel::parsers::character::*;


### PR DESCRIPTION
# Introduction
This PR removes all unnecessary `extern crate` references which are not required for the 2018 edition of rust.

# Linked Issues
resolves #95 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
