### PR TITLE
Update backend to use preparser types

### DIFF
--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -10,7 +10,7 @@ use crate::addressing::{Positional, SizeOf};
 use crate::backends::mos6502::instruction_set::addressing_mode::AddressingModeOrReference;
 use crate::backends::mos6502::instruction_set::Instruction;
 use crate::backends::BackendErr;
-use crate::preparser::{types, ByteValue, PrimitiveOrReference, Token};
+use crate::preparser::{types, PrimitiveOrReference, Token};
 use crate::{Assembler, AssemblerResult};
 use crate::{Emitter, Origin};
 use isa_mos6502::addressing_mode::AddressingMode;
@@ -141,7 +141,7 @@ fn generate_symbol_table_from_instructions_origin(
                 }
                 Token::Symbol((id, bv)) => {
                     let sv = match bv {
-                        ByteValue::Byte(v) => v,
+                        types::PrimitiveVariant::Uint8(pv) => pv.unwrap(),
                         e => panic!(format!("Backend only supports u8: passed {:?}", e)),
                     };
 

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::preparser::{types::Primitive, ByteValue, PreParser, PrimitiveOrReference, Token};
+use crate::preparser::{types, PreParser, PrimitiveOrReference, Token};
 use parcel::prelude::v1::*;
 
 macro_rules! chars {
@@ -48,7 +48,7 @@ fn should_parse_single_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                ByteValue::Byte(255)
+                types::PrimitiveVariant::from(types::Primitive::new(255u8))
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -64,7 +64,7 @@ fn should_parse_two_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                ByteValue::Word(65535)
+                types::PrimitiveVariant::from(types::Primitive::new(65535u16))
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -80,7 +80,7 @@ fn should_parse_four_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                ByteValue::DoubleWord(4294967295)
+                types::PrimitiveVariant::from(types::Primitive::new(4294967295u32))
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -118,13 +118,13 @@ fn should_parse_constants() {
             &input[input.len()..],
             vec![crate::Origin::new(vec![
                 Token::Constant(PrimitiveOrReference::Primitive(
-                    Primitive::new(0x1au8).into()
+                    types::PrimitiveVariant::from(types::Primitive::new(0x1au8))
                 )),
                 Token::Constant(PrimitiveOrReference::Primitive(
-                    Primitive::new(0x1a2bu16).into()
+                    types::PrimitiveVariant::from(types::Primitive::new(0x1a2bu16))
                 )),
                 Token::Constant(PrimitiveOrReference::Primitive(
-                    Primitive::new(0x1a2b3c4du32).into()
+                    types::PrimitiveVariant::from(types::Primitive::new(0x1a2b3c4du32))
                 ))
             ]),]
         ))),
@@ -147,7 +147,7 @@ fn should_parse_constants_as_origin_statement() {
             vec![crate::Origin::with_offset(
                 0x03,
                 vec![Token::Constant(PrimitiveOrReference::Primitive(
-                    Primitive::new(0x1au8).into()
+                    types::PrimitiveVariant::from(types::Primitive::new(0x1au8))
                 )),]
             ),]
         ))),
@@ -172,7 +172,10 @@ init:
             &input[input.len()..],
             vec![
                 crate::Origin::new(vec![
-                    Token::Symbol(("test".to_string(), ByteValue::Byte(0xff))),
+                    Token::Symbol((
+                        "test".to_string(),
+                        types::PrimitiveVariant::from(types::Primitive::new(0xffu8))
+                    )),
                     Token::Label("init".to_string())
                 ]),
                 crate::Origin::with_offset(

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::preparser::{ByteValue, ByteValueOrReference, PreParser, Token};
+use crate::preparser::{types::Primitive, ByteValue, PreParser, PrimitiveOrReference, Token};
 use parcel::prelude::v1::*;
 
 macro_rules! chars {
@@ -117,11 +117,15 @@ fn should_parse_constants() {
         Ok(MatchStatus::Match((
             &input[input.len()..],
             vec![crate::Origin::new(vec![
-                Token::Constant(ByteValueOrReference::ByteValue(ByteValue::Byte(0x1a))),
-                Token::Constant(ByteValueOrReference::ByteValue(ByteValue::Word(0x1a2b))),
-                Token::Constant(ByteValueOrReference::ByteValue(ByteValue::DoubleWord(
-                    0x1a2b3c4d
-                )))
+                Token::Constant(PrimitiveOrReference::Primitive(
+                    Primitive::new(0x1au8).into()
+                )),
+                Token::Constant(PrimitiveOrReference::Primitive(
+                    Primitive::new(0x1a2bu16).into()
+                )),
+                Token::Constant(PrimitiveOrReference::Primitive(
+                    Primitive::new(0x1a2b3c4du32).into()
+                ))
             ]),]
         ))),
         PreParser::new().parse(&input)
@@ -142,8 +146,8 @@ fn should_parse_constants_as_origin_statement() {
             &input[input.len()..],
             vec![crate::Origin::with_offset(
                 0x03,
-                vec![Token::Constant(ByteValueOrReference::ByteValue(
-                    ByteValue::Byte(0x1a)
+                vec![Token::Constant(PrimitiveOrReference::Primitive(
+                    Primitive::new(0x1au8).into()
                 )),]
             ),]
         ))),
@@ -174,8 +178,8 @@ init:
                 crate::Origin::with_offset(
                     0x03,
                     vec![
-                        Token::Constant(ByteValueOrReference::Reference("init".to_string())),
-                        Token::Constant(ByteValueOrReference::Reference("test".to_string()))
+                        Token::Constant(PrimitiveOrReference::Reference("init".to_string())),
+                        Token::Constant(PrimitiveOrReference::Reference("test".to_string()))
                     ]
                 ),
             ]

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -1,0 +1,199 @@
+/// Type System errors.
+#[derive(Clone, PartialEq)]
+pub enum TypeError {
+    IllegalType(String),
+}
+
+impl std::fmt::Debug for TypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IllegalType(v) => write!(f, "illegal type: {:?}", v),
+        }
+    }
+}
+
+/// Represents all variants of accepted types without their associated values.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PrimitiveType {
+    Uint8,
+    Uint16,
+    Uint32,
+}
+
+impl From<PrimitiveVariant> for PrimitiveType {
+    fn from(src: PrimitiveVariant) -> PrimitiveType {
+        std::convert::From::from(&src)
+    }
+}
+
+impl From<&PrimitiveVariant> for PrimitiveType {
+    fn from(src: &PrimitiveVariant) -> PrimitiveType {
+        match src {
+            PrimitiveVariant::Uint8(_) => Self::Uint8,
+            PrimitiveVariant::Uint16(_) => Self::Uint16,
+            PrimitiveVariant::Uint32(_) => Self::Uint32,
+        }
+    }
+}
+
+/// A concrete type representing all valid type variants for the preparser.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PrimitiveVariant {
+    Uint8(Primitive<u8>),
+    Uint16(Primitive<u16>),
+    Uint32(Primitive<u32>),
+}
+
+impl crate::Emitter<Vec<u8>> for PrimitiveVariant {
+    fn emit(&self) -> Vec<u8> {
+        match *self {
+            Self::Uint8(v) => v.unwrap().to_ne_bytes().to_vec(),
+            Self::Uint16(v) => v.unwrap().to_ne_bytes().to_vec(),
+            Self::Uint32(v) => v.unwrap().to_ne_bytes().to_vec(),
+        }
+    }
+}
+
+impl crate::addressing::SizeOf for PrimitiveVariant {
+    fn size_of(&self) -> usize {
+        match *self {
+            Self::Uint8(_) => 1,
+            Self::Uint16(_) => 2,
+            Self::Uint32(_) => 4,
+        }
+    }
+}
+
+impl From<Primitive<u8>> for PrimitiveVariant {
+    fn from(src: Primitive<u8>) -> Self {
+        PrimitiveVariant::Uint8(src)
+    }
+}
+
+impl From<Primitive<u16>> for PrimitiveVariant {
+    fn from(src: Primitive<u16>) -> Self {
+        PrimitiveVariant::Uint16(src)
+    }
+}
+
+impl From<Primitive<u32>> for PrimitiveVariant {
+    fn from(src: Primitive<u32>) -> Self {
+        PrimitiveVariant::Uint32(src)
+    }
+}
+
+impl std::convert::TryFrom<PrimitiveVariant> for Primitive<u8> {
+    type Error = TypeError;
+
+    fn try_from(src: PrimitiveVariant) -> Result<Self, Self::Error> {
+        match src {
+            PrimitiveVariant::Uint8(p) => Ok(p),
+            PrimitiveVariant::Uint16(p) => Err(TypeError::IllegalType(p.to_string())),
+            PrimitiveVariant::Uint32(p) => Err(TypeError::IllegalType(p.to_string())),
+        }
+    }
+}
+
+impl std::convert::TryFrom<PrimitiveVariant> for Primitive<u16> {
+    type Error = TypeError;
+
+    fn try_from(src: PrimitiveVariant) -> Result<Self, Self::Error> {
+        match src {
+            PrimitiveVariant::Uint8(p) => Ok(Primitive::new(u16::from(p.unwrap()))),
+            PrimitiveVariant::Uint16(p) => Ok(p),
+            PrimitiveVariant::Uint32(p) => Err(TypeError::IllegalType(p.to_string())),
+        }
+    }
+}
+
+impl std::convert::TryFrom<PrimitiveVariant> for Primitive<u32> {
+    type Error = TypeError;
+
+    fn try_from(src: PrimitiveVariant) -> Result<Self, Self::Error> {
+        match src {
+            PrimitiveVariant::Uint8(p) => Ok(Primitive::new(u32::from(p.unwrap()))),
+            PrimitiveVariant::Uint16(p) => Ok(Primitive::new(u32::from(p.unwrap()))),
+            PrimitiveVariant::Uint32(p) => Ok(p),
+        }
+    }
+}
+
+/// Primitive wraps rust primitive
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Primitive<T> {
+    inner: T,
+}
+
+impl<T> Primitive<T> {
+    /// Instantiates a new Primitive from an internal type.
+    #[allow(dead_code)]
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the enclosed value of the primitive.
+    #[allow(dead_code)]
+    pub fn unwrap(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> std::fmt::Display for Primitive<T>
+where
+    T: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl std::convert::From<Primitive<u8>> for Primitive<u16> {
+    fn from(src: Primitive<u8>) -> Self {
+        Primitive::new(u16::from(src.unwrap()))
+    }
+}
+
+impl std::convert::From<Primitive<u8>> for Primitive<u32> {
+    fn from(src: Primitive<u8>) -> Self {
+        Primitive::new(u32::from(src.unwrap()))
+    }
+}
+
+impl std::convert::From<Primitive<u16>> for Primitive<u32> {
+    fn from(src: Primitive<u16>) -> Self {
+        Primitive::new(u32::from(src.unwrap()))
+    }
+}
+
+impl std::ops::Add for Primitive<u8> {
+    type Output = Primitive<u8>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let lhs = self.unwrap();
+        let rhs = rhs.unwrap();
+        let sum = lhs.overflowing_add(rhs).0;
+        Primitive::new(sum)
+    }
+}
+
+impl std::ops::Add for Primitive<u16> {
+    type Output = Primitive<u16>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let lhs = self.unwrap();
+        let rhs = rhs.unwrap();
+        let sum = lhs.overflowing_add(rhs).0;
+        Primitive::new(sum)
+    }
+}
+
+impl std::ops::Add for Primitive<u32> {
+    type Output = Primitive<u32>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let lhs = self.unwrap();
+        let rhs = rhs.unwrap();
+        let sum = lhs.overflowing_add(rhs).0;
+        Primitive::new(sum)
+    }
+}


### PR DESCRIPTION
# Introduction
This PR updates the backend to initially use the Primitive types with no other changes. This should be entirely transparent to end users, making no changes to errors or other processes.

# Linked Issues
resolves #103 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
