### PR TITLE
Bit Depth encoded Preparser Primitive

### DIFF
--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -25,7 +25,7 @@ type LabelMap = HashMap<String, u16>;
 type SymbolMap = HashMap<String, u8>;
 
 use crate::preparser::types::Reify;
-impl crate::preparser::types::Reify<u8> for crate::preparser::types::BitValue {
+impl crate::preparser::types::Reify<u8> for crate::preparser::types::LEByteEncodedValue {
     type Error = crate::preparser::types::TypeError;
 
     fn reify(&self) -> Result<u8, Self::Error> {
@@ -173,7 +173,10 @@ fn generate_symbol_table_from_instructions_origin(
 fn dereference_instructions_to_static_instructions(
     symbol_table: &SymbolTable,
     src_ioc: InstructionOrConstant<Instruction, PrimitiveOrReference>,
-) -> Result<InstructionOrConstant<isa_mos6502::InstructionVariant, types::BitValue>, BackendErr> {
+) -> Result<
+    InstructionOrConstant<isa_mos6502::InstructionVariant, types::LEByteEncodedValue>,
+    BackendErr,
+> {
     match src_ioc {
         InstructionOrConstant::Instruction(i) => {
             let mnemonic = i.mnemonic;
@@ -202,12 +205,12 @@ fn dereference_instructions_to_static_instructions(
             PrimitiveOrReference::Reference(id) => symbol_table
                 .labels
                 .get(&id)
-                .map(|&v| types::BitValue::from(v))
+                .map(|&v| types::LEByteEncodedValue::from(v))
                 .or_else(|| {
                     symbol_table
                         .symbols
                         .get(&id)
-                        .map(|&v| types::BitValue::from(v))
+                        .map(|&v| types::LEByteEncodedValue::from(v))
                 })
                 .ok_or_else(|| BackendErr::UndefinedReference(id.clone())),
         }
@@ -270,7 +273,10 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
                     .map(|(st, ioc)| dereference_instructions_to_static_instructions(st, ioc))
                     .collect::<Result<
                         Vec<
-                            InstructionOrConstant<isa_mos6502::InstructionVariant, types::BitValue>,
+                            InstructionOrConstant<
+                                isa_mos6502::InstructionVariant,
+                                types::LEByteEncodedValue,
+                            >,
                         >,
                         BackendErr,
                     >>()?

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -21,7 +21,7 @@ pub type SymbolId = String;
 /// either a static value or a reference.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrimitiveOrReference {
-    Primitive(types::BitValue),
+    Primitive(types::LEByteEncodedValue),
     Reference(String),
 }
 
@@ -31,7 +31,7 @@ pub enum PrimitiveOrReference {
 pub enum Token<T> {
     Instruction(T),
     Label(Label),
-    Symbol((SymbolId, types::BitValue)),
+    Symbol((SymbolId, types::LEByteEncodedValue)),
     Constant(PrimitiveOrReference),
 }
 
@@ -169,7 +169,7 @@ fn byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
             unsigned8(),
         ),
     ))
-    .map(|(s, v)| Token::Symbol((s.into_iter().collect(), types::BitValue::from(v))))
+    .map(|(s, v)| Token::Symbol((s.into_iter().collect(), types::LEByteEncodedValue::from(v))))
 }
 
 fn two_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
@@ -186,7 +186,7 @@ fn two_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
             unsigned16(),
         ),
     ))
-    .map(|(s, v)| Token::Symbol((s.into_iter().collect(), types::BitValue::from(v))))
+    .map(|(s, v)| Token::Symbol((s.into_iter().collect(), types::LEByteEncodedValue::from(v))))
 }
 
 fn four_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
@@ -203,7 +203,7 @@ fn four_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
             unsigned32(),
         ),
     ))
-    .map(|(s, v)| Token::Symbol((s.into_iter().collect(), types::BitValue::from(v))))
+    .map(|(s, v)| Token::Symbol((s.into_iter().collect(), types::LEByteEncodedValue::from(v))))
 }
 
 fn origin<'a>() -> impl parcel::Parser<'a, &'a [char], u32> {
@@ -225,7 +225,7 @@ fn const_byte<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrReference>
     right(join(
         join(expect_str(".byte"), one_or_more(non_newline_whitespace())),
         unsigned8()
-            .map(|b| PrimitiveOrReference::Primitive(types::BitValue::from(b)))
+            .map(|b| PrimitiveOrReference::Primitive(types::LEByteEncodedValue::from(b)))
             .or(|| {
                 one_or_more(alphabetic())
                     .map(|vc| PrimitiveOrReference::Reference(vc.into_iter().collect()))
@@ -237,7 +237,7 @@ fn const_word<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrReference>
     right(join(
         join(expect_str(".word"), one_or_more(non_newline_whitespace())),
         unsigned16()
-            .map(|w| PrimitiveOrReference::Primitive(types::BitValue::from(w)))
+            .map(|w| PrimitiveOrReference::Primitive(types::LEByteEncodedValue::from(w)))
             .or(|| {
                 one_or_more(alphabetic())
                     .map(|vc| PrimitiveOrReference::Reference(vc.into_iter().collect()))
@@ -252,7 +252,7 @@ fn const_doubleword<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrRefe
             one_or_more(non_newline_whitespace()),
         ),
         unsigned32()
-            .map(|dw| PrimitiveOrReference::Primitive(types::BitValue::from(dw)))
+            .map(|dw| PrimitiveOrReference::Primitive(types::LEByteEncodedValue::from(dw)))
             .or(|| {
                 one_or_more(alphabetic())
                     .map(|vc| PrimitiveOrReference::Reference(vc.into_iter().collect()))

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -21,7 +21,7 @@ pub type SymbolId = String;
 /// either a static value or a reference.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrimitiveOrReference {
-    Primitive(types::PrimitiveVariant),
+    Primitive(types::BitValue),
     Reference(String),
 }
 
@@ -31,7 +31,7 @@ pub enum PrimitiveOrReference {
 pub enum Token<T> {
     Instruction(T),
     Label(Label),
-    Symbol((SymbolId, types::PrimitiveVariant)),
+    Symbol((SymbolId, types::BitValue)),
     Constant(PrimitiveOrReference),
 }
 
@@ -169,12 +169,7 @@ fn byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
             unsigned8(),
         ),
     ))
-    .map(|(s, v)| {
-        Token::Symbol((
-            s.into_iter().collect(),
-            types::PrimitiveVariant::from(types::Primitive::new(v)),
-        ))
-    })
+    .map(|(s, v)| Token::Symbol((s.into_iter().collect(), types::BitValue::from(v))))
 }
 
 fn two_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
@@ -191,12 +186,7 @@ fn two_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
             unsigned16(),
         ),
     ))
-    .map(|(s, v)| {
-        Token::Symbol((
-            s.into_iter().collect(),
-            types::PrimitiveVariant::from(types::Primitive::new(v)),
-        ))
-    })
+    .map(|(s, v)| Token::Symbol((s.into_iter().collect(), types::BitValue::from(v))))
 }
 
 fn four_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
@@ -213,12 +203,7 @@ fn four_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
             unsigned32(),
         ),
     ))
-    .map(|(s, v)| {
-        Token::Symbol((
-            s.into_iter().collect(),
-            types::PrimitiveVariant::from(types::Primitive::new(v)),
-        ))
-    })
+    .map(|(s, v)| Token::Symbol((s.into_iter().collect(), types::BitValue::from(v))))
 }
 
 fn origin<'a>() -> impl parcel::Parser<'a, &'a [char], u32> {
@@ -240,7 +225,7 @@ fn const_byte<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrReference>
     right(join(
         join(expect_str(".byte"), one_or_more(non_newline_whitespace())),
         unsigned8()
-            .map(|b| PrimitiveOrReference::Primitive(types::Primitive::new(b).into()))
+            .map(|b| PrimitiveOrReference::Primitive(types::BitValue::from(b)))
             .or(|| {
                 one_or_more(alphabetic())
                     .map(|vc| PrimitiveOrReference::Reference(vc.into_iter().collect()))
@@ -252,7 +237,7 @@ fn const_word<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrReference>
     right(join(
         join(expect_str(".word"), one_or_more(non_newline_whitespace())),
         unsigned16()
-            .map(|w| PrimitiveOrReference::Primitive(types::Primitive::new(w).into()))
+            .map(|w| PrimitiveOrReference::Primitive(types::BitValue::from(w)))
             .or(|| {
                 one_or_more(alphabetic())
                     .map(|vc| PrimitiveOrReference::Reference(vc.into_iter().collect()))
@@ -267,7 +252,7 @@ fn const_doubleword<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrRefe
             one_or_more(non_newline_whitespace()),
         ),
         unsigned32()
-            .map(|dw| PrimitiveOrReference::Primitive(types::Primitive::new(dw).into()))
+            .map(|dw| PrimitiveOrReference::Primitive(types::BitValue::from(dw)))
             .or(|| {
                 one_or_more(alphabetic())
                     .map(|vc| PrimitiveOrReference::Reference(vc.into_iter().collect()))

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -48,7 +48,7 @@ fn should_parse_single_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                types::BitValue::from(255u8)
+                types::LEByteEncodedValue::from(255u8)
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -64,7 +64,7 @@ fn should_parse_two_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                types::BitValue::from(65535u16)
+                types::LEByteEncodedValue::from(65535u16)
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -80,7 +80,7 @@ fn should_parse_four_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                types::BitValue::from(4294967295u32)
+                types::LEByteEncodedValue::from(4294967295u32)
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -117,15 +117,15 @@ fn should_parse_constants() {
         Ok(MatchStatus::Match((
             &input[input.len()..],
             vec![crate::Origin::new(vec![
-                Token::Constant(PrimitiveOrReference::Primitive(types::BitValue::from(
-                    0x1au8
-                ))),
-                Token::Constant(PrimitiveOrReference::Primitive(types::BitValue::from(
-                    0x1a2bu16
-                ))),
-                Token::Constant(PrimitiveOrReference::Primitive(types::BitValue::from(
-                    0x1a2b3c4du32
-                )))
+                Token::Constant(PrimitiveOrReference::Primitive(
+                    types::LEByteEncodedValue::from(0x1au8)
+                )),
+                Token::Constant(PrimitiveOrReference::Primitive(
+                    types::LEByteEncodedValue::from(0x1a2bu16)
+                )),
+                Token::Constant(PrimitiveOrReference::Primitive(
+                    types::LEByteEncodedValue::from(0x1a2b3c4du32)
+                ))
             ]),]
         ))),
         PreParser::new().parse(&input)
@@ -147,7 +147,7 @@ fn should_parse_constants_as_origin_statement() {
             vec![crate::Origin::with_offset(
                 0x03,
                 vec![Token::Constant(PrimitiveOrReference::Primitive(
-                    types::BitValue::from(0x1au8)
+                    types::LEByteEncodedValue::from(0x1au8)
                 )),]
             ),]
         ))),
@@ -172,7 +172,7 @@ init:
             &input[input.len()..],
             vec![
                 crate::Origin::new(vec![
-                    Token::Symbol(("test".to_string(), types::BitValue::from(0xffu8))),
+                    Token::Symbol(("test".to_string(), types::LEByteEncodedValue::from(0xffu8))),
                     Token::Label("init".to_string())
                 ]),
                 crate::Origin::with_offset(

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -48,7 +48,7 @@ fn should_parse_single_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                types::PrimitiveVariant::from(types::Primitive::new(255u8))
+                types::BitValue::from(255u8)
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -64,7 +64,7 @@ fn should_parse_two_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                types::PrimitiveVariant::from(types::Primitive::new(65535u16))
+                types::BitValue::from(65535u16)
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -80,7 +80,7 @@ fn should_parse_four_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol((
                 "test".to_string(),
-                types::PrimitiveVariant::from(types::Primitive::new(4294967295u32))
+                types::BitValue::from(4294967295u32)
             ))])]
         ))),
         PreParser::new().parse(&input)
@@ -117,15 +117,15 @@ fn should_parse_constants() {
         Ok(MatchStatus::Match((
             &input[input.len()..],
             vec![crate::Origin::new(vec![
-                Token::Constant(PrimitiveOrReference::Primitive(
-                    types::PrimitiveVariant::from(types::Primitive::new(0x1au8))
-                )),
-                Token::Constant(PrimitiveOrReference::Primitive(
-                    types::PrimitiveVariant::from(types::Primitive::new(0x1a2bu16))
-                )),
-                Token::Constant(PrimitiveOrReference::Primitive(
-                    types::PrimitiveVariant::from(types::Primitive::new(0x1a2b3c4du32))
-                ))
+                Token::Constant(PrimitiveOrReference::Primitive(types::BitValue::from(
+                    0x1au8
+                ))),
+                Token::Constant(PrimitiveOrReference::Primitive(types::BitValue::from(
+                    0x1a2bu16
+                ))),
+                Token::Constant(PrimitiveOrReference::Primitive(types::BitValue::from(
+                    0x1a2b3c4du32
+                )))
             ]),]
         ))),
         PreParser::new().parse(&input)
@@ -147,7 +147,7 @@ fn should_parse_constants_as_origin_statement() {
             vec![crate::Origin::with_offset(
                 0x03,
                 vec![Token::Constant(PrimitiveOrReference::Primitive(
-                    types::PrimitiveVariant::from(types::Primitive::new(0x1au8))
+                    types::BitValue::from(0x1au8)
                 )),]
             ),]
         ))),
@@ -172,10 +172,7 @@ init:
             &input[input.len()..],
             vec![
                 crate::Origin::new(vec![
-                    Token::Symbol((
-                        "test".to_string(),
-                        types::PrimitiveVariant::from(types::Primitive::new(0xffu8))
-                    )),
+                    Token::Symbol(("test".to_string(), types::BitValue::from(0xffu8))),
                     Token::Label("init".to_string())
                 ]),
                 crate::Origin::with_offset(

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -12,6 +12,27 @@ impl std::fmt::Debug for TypeError {
     }
 }
 
+/// BitValue represents a 64-bit maximum value. This value attempts to define
+/// the minimum number of bits that are required to store a given value without
+/// being concerned with what the value is.
+#[derive(Clone)]
+pub struct BitValue {
+    inner: Vec<u8>,
+}
+
+impl BitValue {
+    pub fn leading_zeros(&self) -> usize {
+        self.inner.last().map_or(0, |b| b.leading_zeros() as usize)
+    }
+}
+
+impl From<u64> for BitValue {
+    fn from(src: u64) -> Self {
+        let le_bytes = src.to_le_bytes().to_vec();
+        Self { inner: le_bytes }
+    }
+}
+
 /// Represents all variants of accepted types without their associated values.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PrimitiveType {

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -12,209 +12,69 @@ impl std::fmt::Debug for TypeError {
     }
 }
 
-/// BitValue represents a 64-bit maximum value. This value attempts to define
-/// the minimum number of bits that are required to store a given value without
-/// being concerned with what the value is.
-#[derive(Clone)]
+/// Reify functions to convert a type to a more concrete type.
+pub trait Reify<T> {
+    type Error;
+
+    fn reify(&self) -> Result<T, Self::Error>;
+}
+
+/// BitValue represents an arbitrarily length binary value encoded in little-endian format
+#[derive(Debug, Clone, PartialEq)]
 pub struct BitValue {
     inner: Vec<u8>,
 }
 
 impl BitValue {
-    pub fn leading_zeros(&self) -> usize {
-        self.inner.last().map_or(0, |b| b.leading_zeros() as usize)
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn leading_zeros(&self) -> usize {
+        self.inner.last().map_or(8, |b| b.leading_zeros() as usize)
+    }
+
+    // Returns the value as a little-endian encoded Vec<u8>
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.inner.clone()
+    }
+
+    /// bits outputs the number of bits needed to express a value.
+    pub fn bits(&self) -> usize {
+        let leading_bits = 8 - self.leading_zeros();
+        // bytes in addition to the most significant byte
+        let bytes = if self.inner.len() > 0 {
+            self.inner.len() - 1
+        } else {
+            0
+        };
+
+        (bytes * 8) + leading_bits
     }
 }
 
-impl From<u64> for BitValue {
-    fn from(src: u64) -> Self {
-        let le_bytes = src.to_le_bytes().to_vec();
-        Self { inner: le_bytes }
-    }
-}
-
-/// Represents all variants of accepted types without their associated values.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PrimitiveType {
-    Uint8,
-    Uint16,
-    Uint32,
-}
-
-impl From<PrimitiveVariant> for PrimitiveType {
-    fn from(src: PrimitiveVariant) -> PrimitiveType {
-        std::convert::From::from(&src)
-    }
-}
-
-impl From<&PrimitiveVariant> for PrimitiveType {
-    fn from(src: &PrimitiveVariant) -> PrimitiveType {
-        match src {
-            PrimitiveVariant::Uint8(_) => Self::Uint8,
-            PrimitiveVariant::Uint16(_) => Self::Uint16,
-            PrimitiveVariant::Uint32(_) => Self::Uint32,
-        }
-    }
-}
-
-/// A concrete type representing all valid type variants for the preparser.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PrimitiveVariant {
-    Uint8(Primitive<u8>),
-    Uint16(Primitive<u16>),
-    Uint32(Primitive<u32>),
-}
-
-impl crate::Emitter<Vec<u8>> for PrimitiveVariant {
-    fn emit(&self) -> Vec<u8> {
-        match *self {
-            Self::Uint8(v) => v.unwrap().to_ne_bytes().to_vec(),
-            Self::Uint16(v) => v.unwrap().to_ne_bytes().to_vec(),
-            Self::Uint32(v) => v.unwrap().to_ne_bytes().to_vec(),
-        }
-    }
-}
-
-impl crate::addressing::SizeOf for PrimitiveVariant {
+impl crate::addressing::SizeOf for BitValue {
     fn size_of(&self) -> usize {
-        match *self {
-            Self::Uint8(_) => 1,
-            Self::Uint16(_) => 2,
-            Self::Uint32(_) => 4,
-        }
+        self.len()
     }
 }
 
-impl From<Primitive<u8>> for PrimitiveVariant {
-    fn from(src: Primitive<u8>) -> Self {
-        PrimitiveVariant::Uint8(src)
+impl crate::Emitter<Vec<u8>> for BitValue {
+    fn emit(&self) -> Vec<u8> {
+        self.inner.clone().into_iter().collect()
     }
 }
 
-impl From<Primitive<u16>> for PrimitiveVariant {
-    fn from(src: Primitive<u16>) -> Self {
-        PrimitiveVariant::Uint16(src)
-    }
+macro_rules! impl_from_to_le_bytes {
+    ($($t:ty,)*) => {
+        $(
+            impl From<$t> for BitValue {
+                fn from(src: $t) -> Self {
+                    Self { inner: src.to_le_bytes().to_vec() }
+                }
+            }
+        )*
+    };
 }
 
-impl From<Primitive<u32>> for PrimitiveVariant {
-    fn from(src: Primitive<u32>) -> Self {
-        PrimitiveVariant::Uint32(src)
-    }
-}
-
-impl std::convert::TryFrom<PrimitiveVariant> for Primitive<u8> {
-    type Error = TypeError;
-
-    fn try_from(src: PrimitiveVariant) -> Result<Self, Self::Error> {
-        match src {
-            PrimitiveVariant::Uint8(p) => Ok(p),
-            PrimitiveVariant::Uint16(p) => Err(TypeError::IllegalType(p.to_string())),
-            PrimitiveVariant::Uint32(p) => Err(TypeError::IllegalType(p.to_string())),
-        }
-    }
-}
-
-impl std::convert::TryFrom<PrimitiveVariant> for Primitive<u16> {
-    type Error = TypeError;
-
-    fn try_from(src: PrimitiveVariant) -> Result<Self, Self::Error> {
-        match src {
-            PrimitiveVariant::Uint8(p) => Ok(Primitive::new(u16::from(p.unwrap()))),
-            PrimitiveVariant::Uint16(p) => Ok(p),
-            PrimitiveVariant::Uint32(p) => Err(TypeError::IllegalType(p.to_string())),
-        }
-    }
-}
-
-impl std::convert::TryFrom<PrimitiveVariant> for Primitive<u32> {
-    type Error = TypeError;
-
-    fn try_from(src: PrimitiveVariant) -> Result<Self, Self::Error> {
-        match src {
-            PrimitiveVariant::Uint8(p) => Ok(Primitive::new(u32::from(p.unwrap()))),
-            PrimitiveVariant::Uint16(p) => Ok(Primitive::new(u32::from(p.unwrap()))),
-            PrimitiveVariant::Uint32(p) => Ok(p),
-        }
-    }
-}
-
-/// Primitive wraps rust primitive
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Primitive<T> {
-    inner: T,
-}
-
-impl<T> Primitive<T> {
-    /// Instantiates a new Primitive from an internal type.
-    #[allow(dead_code)]
-    pub fn new(inner: T) -> Self {
-        Self { inner }
-    }
-
-    /// Returns the enclosed value of the primitive.
-    #[allow(dead_code)]
-    pub fn unwrap(self) -> T {
-        self.inner
-    }
-}
-
-impl<T> std::fmt::Display for Primitive<T>
-where
-    T: std::fmt::Display,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl std::convert::From<Primitive<u8>> for Primitive<u16> {
-    fn from(src: Primitive<u8>) -> Self {
-        Primitive::new(u16::from(src.unwrap()))
-    }
-}
-
-impl std::convert::From<Primitive<u8>> for Primitive<u32> {
-    fn from(src: Primitive<u8>) -> Self {
-        Primitive::new(u32::from(src.unwrap()))
-    }
-}
-
-impl std::convert::From<Primitive<u16>> for Primitive<u32> {
-    fn from(src: Primitive<u16>) -> Self {
-        Primitive::new(u32::from(src.unwrap()))
-    }
-}
-
-impl std::ops::Add for Primitive<u8> {
-    type Output = Primitive<u8>;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        let lhs = self.unwrap();
-        let rhs = rhs.unwrap();
-        let sum = lhs.overflowing_add(rhs).0;
-        Primitive::new(sum)
-    }
-}
-
-impl std::ops::Add for Primitive<u16> {
-    type Output = Primitive<u16>;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        let lhs = self.unwrap();
-        let rhs = rhs.unwrap();
-        let sum = lhs.overflowing_add(rhs).0;
-        Primitive::new(sum)
-    }
-}
-
-impl std::ops::Add for Primitive<u32> {
-    type Output = Primitive<u32>;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        let lhs = self.unwrap();
-        let rhs = rhs.unwrap();
-        let sum = lhs.overflowing_add(rhs).0;
-        Primitive::new(sum)
-    }
-}
+impl_from_to_le_bytes!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64,);

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -19,13 +19,13 @@ pub trait Reify<T> {
     fn reify(&self) -> Result<T, Self::Error>;
 }
 
-/// BitValue represents an arbitrarily length binary value encoded in little-endian format
+/// LEByteEncodedValue represents an arbitrarily length binary value encoded in little-endian format
 #[derive(Debug, Clone, PartialEq)]
-pub struct BitValue {
+pub struct LEByteEncodedValue {
     inner: Vec<u8>,
 }
 
-impl BitValue {
+impl LEByteEncodedValue {
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -53,13 +53,13 @@ impl BitValue {
     }
 }
 
-impl crate::addressing::SizeOf for BitValue {
+impl crate::addressing::SizeOf for LEByteEncodedValue {
     fn size_of(&self) -> usize {
         self.len()
     }
 }
 
-impl crate::Emitter<Vec<u8>> for BitValue {
+impl crate::Emitter<Vec<u8>> for LEByteEncodedValue {
     fn emit(&self) -> Vec<u8> {
         self.inner.clone().into_iter().collect()
     }
@@ -68,7 +68,7 @@ impl crate::Emitter<Vec<u8>> for BitValue {
 macro_rules! impl_from_to_le_bytes {
     ($($t:ty,)*) => {
         $(
-            impl From<$t> for BitValue {
+            impl From<$t> for LEByteEncodedValue {
                 fn from(src: $t) -> Self {
                     Self { inner: src.to_le_bytes().to_vec() }
                 }


### PR DESCRIPTION
# Introduction+
This PR moves away from the preparser PrimitiveVariant, in favor of a binary data format that provides methods to reify it into a concrete type that the backend can orient to it's own endian-ness and reify into a concrete type.
# Linked Issues
resolves #107
resolves #106 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
