### PR TITLE
Bugfix/106/leading zeroes should take multiple bytes into account

### DIFF
--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -25,7 +25,7 @@ type LabelMap = HashMap<String, u16>;
 type SymbolMap = HashMap<String, u8>;
 
 use crate::preparser::types::Reify;
-impl crate::preparser::types::Reify<u8> for crate::preparser::types::LEByteEncodedValue {
+impl Reify<u8> for crate::preparser::types::LEByteEncodedValue {
     type Error = crate::preparser::types::TypeError;
 
     fn reify(&self) -> Result<u8, Self::Error> {
@@ -84,8 +84,7 @@ fn parse_string_instructions_origin_to_token_instructions_origin(
         .instructions
         .into_iter()
         .map(|tok| match tok {
-            Token::Label(v) => Ok(Token::Label(v)),
-            Token::Symbol(v) => Ok(Token::Symbol(v)),
+            Token::Symbol(id, v) => Ok(Token::Symbol(id, v)),
             Token::Constant(v) => Ok(Token::Constant(v)),
             Token::Instruction(inst) => {
                 let input = inst.chars().collect::<Vec<char>>();
@@ -151,11 +150,11 @@ fn generate_symbol_table_from_instructions_origin(
                     insts.push(InstructionOrConstant::Constant(bvol));
                     (st, insts)
                 }
-                Token::Label(l) => {
+                Token::Symbol(l, None) => {
                     st.labels.insert(l, offset as u16);
                     (st, insts)
                 }
-                Token::Symbol((id, bv)) => {
+                Token::Symbol(id, Some(bv)) => {
                     let sv = match bv.bits() {
                         bits if bits <= 8 => bv.reify().unwrap(),
                         e => panic!(format!("Backend only supports u8: passed {:?}", e)),

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -33,7 +33,7 @@ fn should_parse_label() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![zero_origin!(vec![Token::Label("test".to_string())])]
+            vec![zero_origin!(vec![Token::Symbol("test".to_string(), None)])]
         ))),
         PreParser::new().parse(&input)
     );
@@ -46,10 +46,10 @@ fn should_parse_single_byte_constant() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![zero_origin!(vec![Token::Symbol((
+            vec![zero_origin!(vec![Token::Symbol(
                 "test".to_string(),
-                types::LEByteEncodedValue::from(255u8)
-            ))])]
+                Some(types::LEByteEncodedValue::from(255u8))
+            )])]
         ))),
         PreParser::new().parse(&input)
     );
@@ -62,10 +62,10 @@ fn should_parse_two_byte_constant() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![zero_origin!(vec![Token::Symbol((
+            vec![zero_origin!(vec![Token::Symbol(
                 "test".to_string(),
-                types::LEByteEncodedValue::from(65535u16)
-            ))])]
+                Some(types::LEByteEncodedValue::from(65535u16))
+            )])]
         ))),
         PreParser::new().parse(&input)
     );
@@ -78,10 +78,10 @@ fn should_parse_four_byte_constant() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &input[input.len()..],
-            vec![zero_origin!(vec![Token::Symbol((
+            vec![zero_origin!(vec![Token::Symbol(
                 "test".to_string(),
-                types::LEByteEncodedValue::from(4294967295u32)
-            ))])]
+                Some(types::LEByteEncodedValue::from(4294967295u32))
+            )])]
         ))),
         PreParser::new().parse(&input)
     );
@@ -172,8 +172,11 @@ init:
             &input[input.len()..],
             vec![
                 crate::Origin::new(vec![
-                    Token::Symbol(("test".to_string(), types::LEByteEncodedValue::from(0xffu8))),
-                    Token::Label("init".to_string())
+                    Token::Symbol(
+                        "test".to_string(),
+                        Some(types::LEByteEncodedValue::from(0xffu8))
+                    ),
+                    Token::Symbol("init".to_string(), None)
                 ]),
                 crate::Origin::with_offset(
                     0x03,

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -19,7 +19,8 @@ pub trait Reify<T> {
     fn reify(&self) -> Result<T, Self::Error>;
 }
 
-/// LEByteEncodedValue represents an arbitrarily length binary value encoded in little-endian format
+/// LEByteEncodedValue represents an arbitrarily length binary value encoded
+/// in little-endian format
 #[derive(Debug, Clone, PartialEq)]
 pub struct LEByteEncodedValue {
     inner: Vec<u8>,
@@ -30,26 +31,35 @@ impl LEByteEncodedValue {
         self.inner.len()
     }
 
-    fn leading_zeros(&self) -> usize {
-        self.inner.last().map_or(8, |b| b.leading_zeros() as usize)
+    #[allow(dead_code)]
+    /// leading_zeros returns the leading zeroes for the concrete type of the
+    /// object. For example, 255u8 returns 0, 255u16 would return 8 when
+    /// encoded as an LEByteEncodedValue much like their corresponding unsigned
+    /// integer type.
+    pub fn leading_zeros(&self) -> usize {
+        self.inner
+            .iter()
+            .rev()
+            .map(|b| b.leading_zeros())
+            .fold(0usize, |acc, x| {
+                if (acc % 8) == 0 {
+                    acc + x as usize
+                } else {
+                    acc
+                }
+            })
     }
-
-    // Returns the value as a little-endian encoded Vec<u8>
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.inner.clone()
-    }
-
     /// bits outputs the number of bits needed to express a value.
     pub fn bits(&self) -> usize {
-        let leading_bits = 8 - self.leading_zeros();
-        // bytes in addition to the most significant byte
-        let bytes = if self.inner.len() > 0 {
-            self.inner.len() - 1
-        } else {
-            0
-        };
+        self.inner
+            .iter()
+            .filter(|x| x.leading_zeros() < 8)
+            .fold(0usize, |acc, &x| acc + (8 - x.leading_zeros()) as usize)
+    }
 
-        (bytes * 8) + leading_bits
+    /// Returns the value as a little-endian encoded Vec<u8>
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.inner.clone()
     }
 }
 
@@ -78,3 +88,30 @@ macro_rules! impl_from_to_le_bytes {
 }
 
 impl_from_to_le_bytes!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64,);
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn should_return_bits_required_to_express_a_type() {
+        assert_eq!(3, super::LEByteEncodedValue::from(4u8).bits());
+        assert_eq!(8, super::LEByteEncodedValue::from(255u8).bits());
+
+        assert_eq!(3, super::LEByteEncodedValue::from(4u16).bits());
+        assert_eq!(8, super::LEByteEncodedValue::from(255u16).bits());
+
+        assert_eq!(3, super::LEByteEncodedValue::from(4u32).bits());
+        assert_eq!(8, super::LEByteEncodedValue::from(255u32).bits());
+    }
+
+    #[test]
+    fn should_return_leading_zeros_for_underlying_type() {
+        assert_eq!(5, super::LEByteEncodedValue::from(4u8).leading_zeros());
+        assert_eq!(0, super::LEByteEncodedValue::from(255u8).leading_zeros());
+
+        assert_eq!(13, super::LEByteEncodedValue::from(4u16).leading_zeros());
+        assert_eq!(8, super::LEByteEncodedValue::from(255u16).leading_zeros());
+
+        assert_eq!(29, super::LEByteEncodedValue::from(4u32).leading_zeros());
+        assert_eq!(24, super::LEByteEncodedValue::from(255u32).leading_zeros());
+    }
+}


### PR DESCRIPTION
# Introduction
This PR fixes a problem with how leading zeros and bits calculated the size of a type. This also removes the concept of labels from the preparser denoting either symbols or non-preparser instructions.
# Linked Issues
#106 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
