### PR TITLE
Begin bubbling up symbol table errors

### DIFF
--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -86,7 +86,7 @@ impl SymbolTable {
     }
 
     fn insert(&mut self, k: &str, v: LEByteEncodedValue) -> Option<LEByteEncodedValue> {
-        self.insert(k, v.clone())
+        self.symbols.insert(k.to_string(), v.clone())
     }
 }
 
@@ -187,12 +187,11 @@ fn generate_symbol_table_from_instructions_origin(
                 Token::Symbol(l, None) => {
                     let normalized_offset = offset as u16;
 
-                    st.symbols
-                        .insert(l, LEByteEncodedValue::from(normalized_offset));
+                    st.insert(&l, LEByteEncodedValue::from(normalized_offset));
                     (st, insts)
                 }
                 Token::Symbol(id, Some(bv)) => {
-                    st.symbols.insert(id, bv);
+                    st.insert(&id, bv);
                     (st, insts)
                 }
             }

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -70,7 +70,7 @@ impl SymbolTable {
     }
 
     fn get(&self, k: &str) -> Option<LEByteEncodedValue> {
-        self.symbols.get(k).map(|v| v.clone())
+        self.symbols.get(k).cloned()
     }
 
     fn get_as_u8(&self, k: &str) -> Option<u8> {
@@ -86,7 +86,7 @@ impl SymbolTable {
     }
 
     fn insert(&mut self, k: &str, v: LEByteEncodedValue) -> Option<LEByteEncodedValue> {
-        self.symbols.insert(k.to_string(), v.clone())
+        self.symbols.insert(k.to_string(), v)
     }
 }
 

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -257,18 +257,21 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
         &self,
         source: Vec<Origin<UnparsedTokenStream>>,
     ) -> AssemblerResult<AssembledOrigins, BackendErr> {
+        // Parse a stream of text tokens into their corresponding types.
         let token_instructions: Vec<Origin<Token6502InstStream>> = source
             .into_iter()
             .map(parse_string_instructions_origin_to_token_instructions_origin)
             .collect::<Result<Vec<Origin<Token6502InstStream>>, parser::ParseErr>>()
             .map_err(|e| BackendErr::Parse(e.to_string()))?;
+
+        // Annotate parsed tokens with their position and offsets.
         let positional_tokens: Vec<Origin<PositionalToken6502Stream>> = token_instructions
             .into_iter()
             .map(convert_token_instructions_origins_to_positional_tokens_origin)
             .collect::<Result<Vec<Origin<PositionalToken6502Stream>>, BackendErr>>()?;
 
-        // Collect the symbols and instructions into a vector with each item
-        // representing an origins contents
+        // Collect the symbols and instructions into a vector of origin-aligned
+        // offsets.
         let (symbol_tables, instructions): (
             Vec<SymbolTable>,
             Vec<Origin<MemoryAligned6502Stream>>,
@@ -279,7 +282,7 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
             .into_iter()
             .unzip();
 
-        // Join all the origin's symbol tables
+        // Join all the origin's symbol tables into a global symbol table
         let symbol_table: SymbolTable = SymbolTable::from(symbol_tables);
 
         let opcode_origins = instructions

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -43,7 +43,7 @@ impl Reify<u16> for crate::preparser::types::LEByteEncodedValue {
     fn reify(&self) -> Result<u16, Self::Error> {
         match self.bits() {
             b if b == 0 => Ok(0),
-            b if b <= 8 => self.reify().map(|b: u8| u16::from(b)),
+            b if b <= 8 => Reify::<u8>::reify(self).map(u16::from),
             b if b > 8 && b <= 16 => {
                 let bytes = self.to_vec();
                 Ok(u16::from_le_bytes([bytes[0], bytes[1]]))

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -139,7 +139,7 @@ fn parse_string_instructions_origin_to_token_instructions_origin(
 
 fn convert_token_instructions_origins_to_positional_tokens_origin(
     source: Origin<Token6502InstStream>,
-) -> Result<Origin<PositionalToken6502Stream>, BackendErr> {
+) -> Origin<PositionalToken6502Stream> {
     let origin_offset = source.offset;
     let tokens = source.instructions;
     let positional_instructions = tokens
@@ -163,7 +163,7 @@ fn convert_token_instructions_origins_to_positional_tokens_origin(
         )
         .1;
 
-    Ok(Origin::with_offset(origin_offset, positional_instructions))
+    Origin::with_offset(origin_offset, positional_instructions)
 }
 
 fn generate_symbol_table_from_instructions_origin(
@@ -268,7 +268,7 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
         let positional_tokens: Vec<Origin<PositionalToken6502Stream>> = token_instructions
             .into_iter()
             .map(convert_token_instructions_origins_to_positional_tokens_origin)
-            .collect::<Result<Vec<Origin<PositionalToken6502Stream>>, BackendErr>>()?;
+            .collect();
 
         // Collect the symbols and instructions into a vector of origin-aligned
         // offsets.

--- a/src/backends/mos6502/parser/mod.rs
+++ b/src/backends/mos6502/parser/mod.rs
@@ -57,7 +57,9 @@ pub fn instruction<'a>() -> impl parcel::Parser<'a, &'a [char], Instruction> {
 
 fn mnemonic<'a>() -> impl parcel::Parser<'a, &'a [char], Mnemonic> {
     take_n(alphabetic(), 3)
-        .map(|m| Mnemonic::try_from(m.into_iter().collect::<String>().as_str()).unwrap())
+        .map(|m| Mnemonic::try_from(m.into_iter().collect::<String>().as_str()))
+        .predicate(|res| res.is_ok())
+        .map(|res| res.unwrap())
 }
 
 #[allow(clippy::redundant_closure)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,10 @@ pub trait Assembler<T, U, E: std::fmt::Display> {
 // opcodes.
 pub fn assemble(backend: Backend, source: &str) -> AssemblerResult<AssembledOrigins, String> {
     let input: Vec<char> = source.chars().collect();
-    let origin_tokens = preparser::PreParser::new().parse(&input).unwrap().unwrap();
+    let origin_tokens = preparser::PreParser::new()
+        .parse(&input)
+        .map(|ms| ms.unwrap())
+        .map_err(|e| e)?;
 
     match backend {
         Backend::MOS6502 => backends::mos6502::MOS6502Assembler::new().assemble(origin_tokens),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -187,3 +187,16 @@ init:
         assemble(Backend::MOS6502, input).map(|res| res.emit())
     );
 }
+
+#[test]
+fn should_throw_an_error_on_invalid_preparser_construct_doesnt_exist() {
+    let input = "
+nop
+lda 0xff
+    
+origin fffc
+.word 0x0001
+";
+
+    assert!(assemble(Backend::MOS6502, input).is_err())
+}


### PR DESCRIPTION
# Introduction
This PR starts the work of removing the concept of symbols and labels and unifying on a single reference type. This simplifies some of the stack so that errors are easier to bubble up.

# Linked Issues
resolves #98 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
