### PR TITLE
Fix bugfix in bits method

### DIFF
--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -28,13 +28,13 @@ impl std::fmt::Display for BackendErr {
 /// Backend represents the backend targets currently supported by spasm.
 #[derive(Debug)]
 pub enum Backend {
-    MOS6502,
+    Mos6502,
 }
 
 impl std::fmt::Display for Backend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let output = match self {
-            Backend::MOS6502 => "mos6502".to_string(),
+            Backend::Mos6502 => "mos6502".to_string(),
         };
 
         write!(f, "{}", output)
@@ -46,7 +46,7 @@ impl TryFrom<&str> for Backend {
 
     fn try_from(src: &str) -> Result<Self, Self::Error> {
         match src {
-            "mos6502" => Ok(Backend::MOS6502),
+            "mos6502" => Ok(Backend::Mos6502),
             _ => Err(format!("unknown backend: {}", &src)),
         }
     }

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -22,7 +22,7 @@ type MemoryAligned6502Stream = Vec<InstructionOrConstant<Instruction, PrimitiveO
 type AssembledOrigins = Vec<Origin<Vec<u8>>>;
 
 use crate::preparser::types::Reify;
-impl Reify<u8> for crate::preparser::types::LEByteEncodedValue {
+impl Reify<u8> for crate::preparser::types::LeByteEncodedValue {
     type Error = crate::preparser::types::TypeError;
 
     fn reify(&self) -> Result<u8, Self::Error> {
@@ -37,7 +37,7 @@ impl Reify<u8> for crate::preparser::types::LEByteEncodedValue {
     }
 }
 
-impl Reify<u16> for crate::preparser::types::LEByteEncodedValue {
+impl Reify<u16> for crate::preparser::types::LeByteEncodedValue {
     type Error = crate::preparser::types::TypeError;
 
     fn reify(&self) -> Result<u16, Self::Error> {
@@ -56,20 +56,20 @@ impl Reify<u16> for crate::preparser::types::LEByteEncodedValue {
     }
 }
 
-type SymbolMap = HashMap<String, LEByteEncodedValue>;
+type SymbolMap = HashMap<String, LeByteEncodedValue>;
 
 #[derive(Default)]
 struct SymbolTable {
     symbols: SymbolMap,
 }
 
-use crate::preparser::types::LEByteEncodedValue;
+use crate::preparser::types::LeByteEncodedValue;
 impl SymbolTable {
     fn new(symbols: SymbolMap) -> Self {
         Self { symbols }
     }
 
-    fn get(&self, k: &str) -> Option<LEByteEncodedValue> {
+    fn get(&self, k: &str) -> Option<LeByteEncodedValue> {
         self.symbols.get(k).cloned()
     }
 
@@ -85,7 +85,7 @@ impl SymbolTable {
             .and_then(|res| res.ok())
     }
 
-    fn insert(&mut self, k: &str, v: LEByteEncodedValue) -> Option<LEByteEncodedValue> {
+    fn insert(&mut self, k: &str, v: LeByteEncodedValue) -> Option<LeByteEncodedValue> {
         self.symbols.insert(k.to_string(), v)
     }
 }
@@ -186,7 +186,7 @@ fn generate_symbol_table_from_instructions_origin(
                 }
                 Token::Symbol(l, None) => {
                     let normalized_offset = offset as u16;
-                    st.insert(&l, LEByteEncodedValue::from(normalized_offset));
+                    st.insert(&l, LeByteEncodedValue::from(normalized_offset));
                     (st, insts)
                 }
                 Token::Symbol(id, Some(bv)) => {
@@ -203,7 +203,7 @@ fn dereference_instructions_to_static_instructions(
     symbol_table: &SymbolTable,
     src_ioc: InstructionOrConstant<Instruction, PrimitiveOrReference>,
 ) -> Result<
-    InstructionOrConstant<isa_mos6502::InstructionVariant, types::LEByteEncodedValue>,
+    InstructionOrConstant<isa_mos6502::InstructionVariant, types::LeByteEncodedValue>,
     BackendErr,
 > {
     match src_ioc {
@@ -238,19 +238,19 @@ fn dereference_instructions_to_static_instructions(
     }
 }
 
-/// MOS6502Assembler functions as a wrapper struct to facilitate an
+/// Mos6502Assembler functions as a wrapper struct to facilitate an
 /// implementation of the Assembler trait for the 6502 instruction set.
 #[derive(Default)]
-pub struct MOS6502Assembler {}
+pub struct Mos6502Assembler {}
 
-impl MOS6502Assembler {
+impl Mos6502Assembler {
     pub fn new() -> Self {
         Self::default()
     }
 }
 
 impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
-    for MOS6502Assembler
+    for Mos6502Assembler
 {
     fn assemble(
         &self,
@@ -291,7 +291,7 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
                         Vec<
                             InstructionOrConstant<
                                 isa_mos6502::InstructionVariant,
-                                types::LEByteEncodedValue,
+                                types::LeByteEncodedValue,
                             >,
                         >,
                         BackendErr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,9 @@ impl<T> From<(usize, T)> for Origin<T> {
     }
 }
 
-impl<T> Into<(usize, T)> for Origin<T> {
-    fn into(self) -> (usize, T) {
-        (self.offset, self.instructions)
+impl<T> From<Origin<T>> for (usize, T) {
+    fn from(src: Origin<T>) -> (usize, T) {
+        (src.offset, src.instructions)
     }
 }
 
@@ -124,7 +124,7 @@ pub fn assemble(backend: Backend, source: &str) -> AssemblerResult<AssembledOrig
         .map_err(|e| e)?;
 
     match backend {
-        Backend::MOS6502 => backends::mos6502::MOS6502Assembler::new().assemble(origin_tokens),
+        Backend::Mos6502 => backends::mos6502::Mos6502Assembler::new().assemble(origin_tokens),
     }
     .map_err(|e| e.to_string())
 }

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -18,7 +18,7 @@ pub type SymbolId = String;
 /// either a static value or a reference.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrimitiveOrReference {
-    Primitive(types::LEByteEncodedValue),
+    Primitive(types::LeByteEncodedValue),
     Reference(String),
 }
 
@@ -31,7 +31,7 @@ pub enum Token<T> {
     /// A value of None signifies that the value can't be determined in the
     /// preparser and will be defined by the backend. One such example is labels
     /// that depend on fixed sized instructions to determine their offset.
-    Symbol(SymbolId, Option<types::LEByteEncodedValue>),
+    Symbol(SymbolId, Option<types::LeByteEncodedValue>),
     Constant(PrimitiveOrReference),
 }
 
@@ -172,7 +172,7 @@ fn byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
     .map(|(s, v)| {
         Token::Symbol(
             s.into_iter().collect(),
-            Some(types::LEByteEncodedValue::from(v)),
+            Some(types::LeByteEncodedValue::from(v)),
         )
     })
 }
@@ -194,7 +194,7 @@ fn two_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
     .map(|(s, v)| {
         Token::Symbol(
             s.into_iter().collect(),
-            Some(types::LEByteEncodedValue::from(v)),
+            Some(types::LeByteEncodedValue::from(v)),
         )
     })
 }
@@ -216,7 +216,7 @@ fn four_byte_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
     .map(|(s, v)| {
         Token::Symbol(
             s.into_iter().collect(),
-            Some(types::LEByteEncodedValue::from(v)),
+            Some(types::LeByteEncodedValue::from(v)),
         )
     })
 }
@@ -240,7 +240,7 @@ fn const_byte<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrReference>
     right(join(
         join(expect_str(".byte"), one_or_more(non_newline_whitespace())),
         unsigned8()
-            .map(|b| PrimitiveOrReference::Primitive(types::LEByteEncodedValue::from(b)))
+            .map(|b| PrimitiveOrReference::Primitive(types::LeByteEncodedValue::from(b)))
             .or(|| {
                 one_or_more(alphabetic())
                     .map(|vc| PrimitiveOrReference::Reference(vc.into_iter().collect()))
@@ -252,7 +252,7 @@ fn const_word<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrReference>
     right(join(
         join(expect_str(".word"), one_or_more(non_newline_whitespace())),
         unsigned16()
-            .map(|w| PrimitiveOrReference::Primitive(types::LEByteEncodedValue::from(w)))
+            .map(|w| PrimitiveOrReference::Primitive(types::LeByteEncodedValue::from(w)))
             .or(|| {
                 one_or_more(alphabetic())
                     .map(|vc| PrimitiveOrReference::Reference(vc.into_iter().collect()))
@@ -267,7 +267,7 @@ fn const_doubleword<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrRefe
             one_or_more(non_newline_whitespace()),
         ),
         unsigned32()
-            .map(|dw| PrimitiveOrReference::Primitive(types::LEByteEncodedValue::from(dw)))
+            .map(|dw| PrimitiveOrReference::Primitive(types::LeByteEncodedValue::from(dw)))
             .or(|| {
                 one_or_more(alphabetic())
                     .map(|vc| PrimitiveOrReference::Reference(vc.into_iter().collect()))

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -48,7 +48,7 @@ fn should_parse_single_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol(
                 "test".to_string(),
-                Some(types::LEByteEncodedValue::from(255u8))
+                Some(types::LeByteEncodedValue::from(255u8))
             )])]
         ))),
         PreParser::new().parse(&input)
@@ -64,7 +64,7 @@ fn should_parse_two_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol(
                 "test".to_string(),
-                Some(types::LEByteEncodedValue::from(65535u16))
+                Some(types::LeByteEncodedValue::from(65535u16))
             )])]
         ))),
         PreParser::new().parse(&input)
@@ -80,7 +80,7 @@ fn should_parse_four_byte_constant() {
             &input[input.len()..],
             vec![zero_origin!(vec![Token::Symbol(
                 "test".to_string(),
-                Some(types::LEByteEncodedValue::from(4294967295u32))
+                Some(types::LeByteEncodedValue::from(4294967295u32))
             )])]
         ))),
         PreParser::new().parse(&input)
@@ -118,13 +118,13 @@ fn should_parse_constants() {
             &input[input.len()..],
             vec![crate::Origin::new(vec![
                 Token::Constant(PrimitiveOrReference::Primitive(
-                    types::LEByteEncodedValue::from(0x1au8)
+                    types::LeByteEncodedValue::from(0x1au8)
                 )),
                 Token::Constant(PrimitiveOrReference::Primitive(
-                    types::LEByteEncodedValue::from(0x1a2bu16)
+                    types::LeByteEncodedValue::from(0x1a2bu16)
                 )),
                 Token::Constant(PrimitiveOrReference::Primitive(
-                    types::LEByteEncodedValue::from(0x1a2b3c4du32)
+                    types::LeByteEncodedValue::from(0x1a2b3c4du32)
                 ))
             ]),]
         ))),
@@ -147,7 +147,7 @@ fn should_parse_constants_as_origin_statement() {
             vec![crate::Origin::with_offset(
                 0x03,
                 vec![Token::Constant(PrimitiveOrReference::Primitive(
-                    types::LEByteEncodedValue::from(0x1au8)
+                    types::LeByteEncodedValue::from(0x1au8)
                 )),]
             ),]
         ))),
@@ -174,7 +174,7 @@ init:
                 crate::Origin::new(vec![
                     Token::Symbol(
                         "test".to_string(),
-                        Some(types::LEByteEncodedValue::from(0xffu8))
+                        Some(types::LeByteEncodedValue::from(0xffu8))
                     ),
                     Token::Symbol("init".to_string(), None)
                 ]),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,7 +21,7 @@ jmp 0x1234\n";
         Ok(vec![zero_origin!(vec![
             0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x10, 0x1a, 0x10, 0xf0, 0x4c, 0x34, 0x12
         ])]),
-        assemble(Backend::MOS6502, input)
+        assemble(Backend::Mos6502, input)
     )
 }
 
@@ -42,7 +42,7 @@ init:
         Ok(vec![zero_origin!(vec![
             0xea, 0xa9, 0x12, 0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x03, 0x00
         ])]),
-        assemble(Backend::MOS6502, input)
+        assemble(Backend::Mos6502, input)
     )
 }
 
@@ -60,7 +60,7 @@ init:
 
     assert_eq!(
         Err("reference undefined: notinit".to_string()),
-        assemble(Backend::MOS6502, input)
+        assemble(Backend::Mos6502, input)
     )
 }
 
@@ -79,7 +79,7 @@ jmp 0x1234
         Ok(vec![zero_origin!(vec![
             0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x34, 0x12
         ])]),
-        assemble(Backend::MOS6502, input)
+        assemble(Backend::Mos6502, input)
     )
 }
 
@@ -94,7 +94,7 @@ jmp 0x1234
 
     assert_eq!(
         Err("reference undefined: test".to_string()),
-        assemble(Backend::MOS6502, input)
+        assemble(Backend::Mos6502, input)
     )
 }
 
@@ -114,7 +114,7 @@ init:
         Ok(vec![zero_origin!(vec![
             0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x00, 0x00
         ])]),
-        assemble(Backend::MOS6502, input)
+        assemble(Backend::Mos6502, input)
     )
 }
 
@@ -134,7 +134,7 @@ init: ; test
         Ok(vec![zero_origin!(vec![
             0xea, 0xa9, 0x12, 0x8d, 0x34, 0x12, 0x4c, 0x00, 0x00
         ])]),
-        assemble(Backend::MOS6502, input)
+        assemble(Backend::Mos6502, input)
     )
 }
 
@@ -150,7 +150,7 @@ nop
 
     assert_eq!(
         Ok(vec![0xea, 0x00, 0x00, 0xea, 0x00, 0x00, 0xea]),
-        assemble(Backend::MOS6502, input).map(|res| res.emit())
+        assemble(Backend::Mos6502, input).map(|res| res.emit())
     );
 }
 
@@ -167,7 +167,7 @@ nop
 
     assert_eq!(
         Ok(vec![0xea, 0x00, 0x00, 0xea, 0x2b, 0x1a, 0xea]),
-        assemble(Backend::MOS6502, input).map(|res| res.emit())
+        assemble(Backend::Mos6502, input).map(|res| res.emit())
     );
 }
 
@@ -184,7 +184,7 @@ init:
 
     assert_eq!(
         Ok(vec![0xea, 0xea, 0x01, 0x00, 0xff]),
-        assemble(Backend::MOS6502, input).map(|res| res.emit())
+        assemble(Backend::Mos6502, input).map(|res| res.emit())
     );
 }
 
@@ -198,5 +198,5 @@ origin fffc
 .word 0x0001
 ";
 
-    assert!(assemble(Backend::MOS6502, input).is_err())
+    assert!(assemble(Backend::Mos6502, input).is_err())
 }


### PR DESCRIPTION
# Introduction
This PR fixes an issue where values that have a least significant byte with 8 leading zeroes incorrectly is calculated as needing 0 bits to be expressed rather than requiring all bits to be expressible due to the leading byte.

Example would be a value you like `0x6000`.

This is correctly calculated by the `leading_zeroes` method on the `LeByteEncodedValue` type and is fixed by updating the bits method to calculate it's needed bits by subtracting it's leading zeros from the total bits of the represented value.

# Linked Issues
resolves #118 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
