### PR TITLE
Strip empty origins resulting from preparser instructions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
 	],
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash",
 		"lldb.executable": "/usr/bin/lldb",
 		// VS Code don't watch files under ./target
 		"files.watcherExclude": {

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -279,6 +279,8 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
 
         let opcode_origins = instructions
             .into_iter()
+            // strip empty origins
+            .filter(|origin| origin.instructions.len() > 0)
             .map(|origin| {
                 let origin_offset = origin.offset;
                 let instructions = origin.instructions;

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -280,7 +280,7 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
         let opcode_origins = instructions
             .into_iter()
             // strip empty origins
-            .filter(|origin| origin.instructions.len() > 0)
+            .filter(|origin| !origin.instructions.is_empty())
             .map(|origin| {
                 let origin_offset = origin.offset;
                 let instructions = origin.instructions;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -200,3 +200,20 @@ origin fffc
 
     assert!(assemble(Backend::Mos6502, input).is_err())
 }
+
+#[test]
+fn should_strip_initial_origin_if_it_only_contains_preparser_directives() {
+    let input = "
+
+.define byte test 0xff
+.origin 0x03
+init:
+  .word       init
+  .byte       test
+";
+
+    assert_eq!(
+        Ok(vec![0x03, 0x00, 0xff]),
+        assemble(Backend::Mos6502, input).map(|res| res.emit())
+    );
+}


### PR DESCRIPTION
# Introduction
This PR strips empty origins when attempting to perform code generation. These origins often result from defines creating existing before an origin block that are stripped when building the symbol table. leaving a block with noting but padding. This PR simply adds a filter to strip any empty origin blocks.

# Linked Issues
resolves #120 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
