### PR TITLE
Initial implementation of character constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ definition      = .define whitespace+ referenceid whitespace+ expression ;
 
 expression      = literal | referenceid;
 
-literal         = byte (byte (byte byte?)?)? ;
+literal         = (byte (byte (byte byte?)?)?) ;
 
 origin          = ".origin" whitespace+ byte (byte (byte byte?)?)? ;
 
@@ -45,7 +45,7 @@ lower           = "a"|"b"|"c"|"d"|"e"|"f"|"g"|"h"|"i"|"j"|"k"|"l"|"m"
                 |"n"|"o"|"p"|"q"|"r"|"s"|"t"|"u"|"v"|"w"|"x"|"y"|"z" ;
 upper           = "A"|"B"|"C"|"D"|"E"|"F"|"G"|"H"|"I"|"J"|"K"|"L"|"M"
                 |"N"|"O"|"P"|"Q"|"R"|"S"|"T"|"U"|"V"|"W"|"X"|"Y"|"Z" ;
-byte            = ( "0x" hex hex ) | digit+ | ( "0b" binarybyte ) ;
+byte            = ( "0x" hex hex ) | digit+ | ( "0b" binarybyte ) | "'" alphabetic "'" ;
 hex             = "0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"a"|"b"|"c"
                 |"d"|"e"|"f"|"A"|"B"|"C"|"D"|"E"|"F" ;
 binarybyte      = binary binary binary binary binary binary binary binary ;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -163,7 +163,7 @@ fn dec_u32<'a>() -> impl Parser<'a, &'a [char], u32> {
         let res = one_or_more(decimal())
             .map(|digits| {
                 let vd: String = digits.into_iter().collect();
-                u32::from_str_radix(&vd, 10)
+                vd.parse::<u32>()
             })
             .parse(input);
 
@@ -182,7 +182,7 @@ fn dec_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
         let res = one_or_more(decimal())
             .map(|digits| {
                 let vd: String = digits.into_iter().collect();
-                u16::from_str_radix(&vd, 10)
+                vd.parse::<u16>()
             })
             .parse(input);
 
@@ -201,7 +201,7 @@ fn dec_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
         let res = one_or_more(decimal())
             .map(|digits| {
                 let vd: String = digits.into_iter().collect();
-                u8::from_str_radix(&vd, 10)
+                vd.parse::<u8>()
             })
             .parse(input);
 
@@ -228,7 +228,7 @@ fn dec_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
                     .into_iter()
                     .chain(digits.into_iter())
                     .collect();
-                i8::from_str_radix(&vd, 10)
+                vd.parse::<i8>()
             })
             .parse(input);
 

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -192,14 +192,10 @@ fn char_def<'a>() -> impl parcel::Parser<'a, &'a [char], Token<String>> {
                 one_or_more(non_newline_whitespace()),
             )),
             expect_character('\'').and_then(|_| {
-                left(join(alphabetic(), expect_character('\''))).map(|c| {
-                    let mut b = [0; 1];
-                    // This is panicable but is protected by the above
-                    // "alphabetic" constraint. Fairly safe due to the
-                    // alphabetic constraint.
-                    c.encode_utf8(&mut b);
-                    b[0]
-                })
+                left(join(
+                    alphabetic().predicate(|c| c.is_ascii_alphabetic()),
+                    expect_character('\''),
+                ))
             }),
         ),
     ))

--- a/src/preparser/mod.rs
+++ b/src/preparser/mod.rs
@@ -291,14 +291,6 @@ fn const_char<'a>() -> impl parcel::Parser<'a, &'a [char], PrimitiveOrReference>
                 alphabetic().predicate(|c| c.is_ascii_alphabetic()),
                 expect_character('\''),
             ))
-            .map(|c| {
-                let mut b = [0; 1];
-                // This is panicable but is protected by the above
-                // "alphabetic" constraint. Fairly safe due to the
-                // alphabetic constraint.
-                c.encode_utf8(&mut b);
-                b[0]
-            })
             .map(|b| PrimitiveOrReference::Primitive(types::LeByteEncodedValue::from(b)))
             .or(|| {
                 one_or_more(alphabetic())

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -153,6 +153,16 @@ fn should_parse_constants() {
 }
 
 #[test]
+fn should_throw_error_on_non_ascii_character_constants() {
+    let input = chars!(".char       '𒀀'");
+
+    assert_eq!(
+        Ok(MatchStatus::NoMatch(&input[..])),
+        PreParser::new().parse(&input)
+    );
+}
+
+#[test]
 fn should_parse_constants_as_origin_statement() {
     let input = chars!(
         "

--- a/src/preparser/tests/mod.rs
+++ b/src/preparser/tests/mod.rs
@@ -56,6 +56,22 @@ fn should_parse_single_byte_constant() {
 }
 
 #[test]
+fn should_parse_single_byte_char_constant() {
+    let input = chars!(".define char test 'a'");
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[input.len()..],
+            vec![zero_origin!(vec![Token::Symbol(
+                "test".to_string(),
+                Some(types::LeByteEncodedValue::from(97u8))
+            )])]
+        ))),
+        PreParser::new().parse(&input)
+    );
+}
+
+#[test]
 fn should_parse_two_byte_constant() {
     let input = chars!(".define word test 65535");
 
@@ -107,6 +123,7 @@ fn should_parse_origin() {
 fn should_parse_constants() {
     let input = chars!(
         "
+.char       'a'
 .byte       0x1a
 .word       0x1a2b
 .doubleword 0x1a2b3c4d
@@ -117,6 +134,9 @@ fn should_parse_constants() {
         Ok(MatchStatus::Match((
             &input[input.len()..],
             vec![crate::Origin::new(vec![
+                Token::Constant(PrimitiveOrReference::Primitive(
+                    types::LeByteEncodedValue::from(0x61u8)
+                )),
                 Token::Constant(PrimitiveOrReference::Primitive(
                     types::LeByteEncodedValue::from(0x1au8)
                 )),

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -93,7 +93,7 @@ impl From<char> for LeByteEncodedValue {
     fn from(value: char) -> Self {
         let mut buffer = [0u8; 4];
         let result = value.encode_utf8(&mut buffer);
-        let byte_vec = result.as_bytes().into_iter().copied().collect();
+        let byte_vec = result.as_bytes().iter().copied().collect();
 
         LeByteEncodedValue::new(byte_vec)
     }

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -27,6 +27,10 @@ pub struct LeByteEncodedValue {
 }
 
 impl LeByteEncodedValue {
+    pub fn new(inner: Vec<u8>) -> Self {
+        Self { inner }
+    }
+
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -76,13 +80,23 @@ impl crate::Emitter<Vec<u8>> for LeByteEncodedValue {
 macro_rules! impl_from_to_le_bytes {
     ($($t:ty,)*) => {
         $(
-            impl From<$t> for LeByteEncodedValue{
+            impl From<$t> for LeByteEncodedValue {
                 fn from(src: $t) -> Self {
                     Self { inner: src.to_le_bytes().to_vec() }
                 }
             }
         )*
     };
+}
+
+impl From<char> for LeByteEncodedValue {
+    fn from(value: char) -> Self {
+        let mut buffer = [0u8; 4];
+        let result = value.encode_utf8(&mut buffer);
+        let byte_vec = result.as_bytes().into_iter().copied().collect();
+
+        LeByteEncodedValue::new(byte_vec)
+    }
 }
 
 impl_from_to_le_bytes!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64,);


### PR DESCRIPTION
# Introduction
This PR adds ascii characters as a type that is recognized by the preparser effectively being translated to an underlying `byte` type.

example:

```
.define byte test 0xff
.define char testchar 'a'

.origin 0x8000
init:
  nop
  lda #test
  lda #testchar

.origin 0xfffc
  .word init
  .char 'a'
  .char 'b'
  ```
yields:

```bash
vscode ➜ /workspaces/spasm (feature/122/character-preparser-types ✗) $ hexdump -C a.out                           
00000000  ea a9 ff a9 61 00 00 00  00 00 00 00 00 00 00 00  |....a...........|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00007ff0  00 00 00 00 00 00 00 00  00 00 00 00 00 80 61 62  |..............ab|
00008000
```

## TODO
- [x] Add test cases that assert non-ascii characters are correctly caught at the parser.


# Linked Issues
resolves #122 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
