### PR TITLE
Jsr generates incorrect opcode

### DIFF
--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -41,7 +41,9 @@ impl Reify<u16> for crate::preparser::types::LeByteEncodedValue {
     type Error = crate::preparser::types::TypeError;
 
     fn reify(&self) -> Result<u16, Self::Error> {
-        match self.bits() {
+        let bits = self.bits();
+        println!("bits: {:?}", &bits);
+        match bits {
             b if b == 0 => Ok(0),
             b if b <= 8 => Reify::<u8>::reify(self).map(u16::from),
             b if b > 8 && b <= 16 => {
@@ -58,7 +60,7 @@ impl Reify<u16> for crate::preparser::types::LeByteEncodedValue {
 
 type SymbolMap = HashMap<String, LeByteEncodedValue>;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct SymbolTable {
     symbols: SymbolMap,
 }
@@ -320,5 +322,17 @@ impl Assembler<Vec<Origin<UnparsedTokenStream>>, AssembledOrigins, BackendErr>
             .collect::<Result<Vec<Origin<Vec<u8>>>, BackendErr>>()?;
 
         Ok(opcode_origins)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_reify_a_16_bit_lebytesvalue() {
+        let lebev = LeByteEncodedValue::new(vec![0, 128]);
+
+        assert_eq!(Ok(0x8000), Reify::<u16>::reify(&lebev))
     }
 }

--- a/src/backends/mos6502/mod.rs
+++ b/src/backends/mos6502/mod.rs
@@ -41,9 +41,7 @@ impl Reify<u16> for crate::preparser::types::LeByteEncodedValue {
     type Error = crate::preparser::types::TypeError;
 
     fn reify(&self) -> Result<u16, Self::Error> {
-        let bits = self.bits();
-        println!("bits: {:?}", &bits);
-        match bits {
+        match self.bits() {
             b if b == 0 => Ok(0),
             b if b <= 8 => Reify::<u8>::reify(self).map(u16::from),
             b if b > 8 && b <= 16 => {

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -116,23 +116,35 @@ mod tests {
     }
 
     #[test]
-    fn should_return_leading_zeros_for_underlying_type() {
-        assert_eq!(5, super::LeByteEncodedValue::from(4u8).leading_zeros());
-        assert_eq!(0, super::LeByteEncodedValue::from(255u8).leading_zeros());
+    fn should_return_leading_zeros_for_u8_type() {
+        for byte in 0..255u8 {
+            let leading_zeros = byte.leading_zeros();
+            assert_eq!(
+                leading_zeros as usize,
+                super::LeByteEncodedValue::from(byte).leading_zeros()
+            );
+        }
+    }
 
-        assert_eq!(13, super::LeByteEncodedValue::from(4u16).leading_zeros());
-        assert_eq!(8, super::LeByteEncodedValue::from(255u16).leading_zeros());
+    #[test]
+    fn should_return_leading_zeros_for_u16_type() {
+        for word in 0..u16::MAX {
+            let leading_zeros = word.leading_zeros();
+            assert_eq!(
+                leading_zeros as usize,
+                super::LeByteEncodedValue::from(word).leading_zeros()
+            );
+        }
+    }
 
-        assert_eq!(
-            1,
-            super::LeByteEncodedValue::from(0x6000u16).leading_zeros()
-        );
-        assert_eq!(
-            0,
-            super::LeByteEncodedValue::from(0x8000u16).leading_zeros()
-        );
-
-        assert_eq!(29, super::LeByteEncodedValue::from(4u32).leading_zeros());
-        assert_eq!(24, super::LeByteEncodedValue::from(255u32).leading_zeros());
+    #[test]
+    fn should_return_leading_zeros_for_u32_type() {
+        for doubleword in 0..u16::MAX as u32 {
+            let leading_zeros = doubleword.leading_zeros();
+            assert_eq!(
+                leading_zeros as usize,
+                super::LeByteEncodedValue::from(doubleword).leading_zeros()
+            );
+        }
     }
 }


### PR DESCRIPTION
# Introduction
Fixes another bug with how leading_zeros were calculated that was causing a specific `0x8000` address to incorrectly say it had 8 leading 0s and qualified as a u8. This PR correctly fixes this and adds parametric tests to prevent this from happening again in the future.

A test case on #124 was tested to validate it now works correctly on real code

# Linked Issues
resolves #124 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
