### PR TITLE
Small refactors for variable naming in leading zeros method and methods in the assembler

### DIFF
--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -54,6 +54,7 @@ impl LeByteEncodedValue {
             // default to total bits as leading zeroes if no 1 bits are found.
             .unwrap_or_else(|| 8 * self.size_of())
     }
+
     /// bits outputs the number of bits needed to express a value.
     pub fn bits(&self) -> usize {
         let bytes = self.inner.len();

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -21,7 +21,7 @@ pub trait Reify<T> {
     fn reify(&self) -> Result<T, Self::Error>;
 }
 
-/// LEByteEncodedValue represents an arbitrarily length binary value encoded
+/// LeByteEncodedValue represents an arbitrarily length binary value encoded
 /// in little-endian format
 #[derive(Debug, Clone, PartialEq)]
 pub struct LeByteEncodedValue {
@@ -39,7 +39,7 @@ impl LeByteEncodedValue {
 
     /// leading_zeros returns the leading zeroes for the concrete type of the
     /// object. For example, 255u8 returns 0, 255u16 would return 8 when
-    /// encoded as an LEByteEncodedValue much like their corresponding unsigned
+    /// encoded as an LeByteEncodedValue much like their corresponding unsigned
     /// integer type.
     pub fn leading_zeros(&self) -> usize {
         self.inner

--- a/src/preparser/types.rs
+++ b/src/preparser/types.rs
@@ -1,3 +1,5 @@
+use crate::addressing::SizeOf;
+
 /// Type System errors.
 #[derive(Clone, PartialEq)]
 pub enum TypeError {
@@ -40,15 +42,17 @@ impl LeByteEncodedValue {
     /// encoded as an LEByteEncodedValue much like their corresponding unsigned
     /// integer type.
     pub fn leading_zeros(&self) -> usize {
-        let bytes = self.inner.len();
         self.inner
             .iter()
             .rev()
             .map(|b| b.leading_zeros())
             .enumerate()
             .find(|(_depth, leading_zeros)| leading_zeros < &8)
-            .map(|(first, leading)| leading as usize + (first * 8))
-            .unwrap_or_else(|| 8 * bytes)
+            // If a byte with a 1 bit is found, multiply the depth by 8 and
+            // add that bits leading zeroes for the total leading zeroes.
+            .map(|(depth, leading_zeros)| leading_zeros as usize + (depth * 8))
+            // default to total bits as leading zeroes if no 1 bits are found.
+            .unwrap_or_else(|| 8 * self.size_of())
     }
     /// bits outputs the number of bits needed to express a value.
     pub fn bits(&self) -> usize {


### PR DESCRIPTION
# Introduction
This PR includes a few small refactors to help with clarity. These exist in the `assemble` method for the mos6502 assembler to break out a really dense `map` call as well as some variable changes to the `leading_zeros` methods to help with clarity.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
