### PR TITLE
Bump to scrap v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ source = "git+https://github.com/ncatelli/parcel?tag=v1.9.1#bd387b7bf7503ad760f5
 [[package]]
 name = "scrap"
 version = "1.0.0"
-source = "git+https://github.com/ncatelli/scrap?branch=main#887854d4af708a40a3c5b0e85e9588e662e12607"
+source = "git+https://github.com/ncatelli/scrap?tag=v1.0.0#293eb9055cfa85fe68070e8c366819e61af677d3"
 
 [[package]]
 name = "spasm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ lto = true
 
 [dependencies]
 parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.9.1" }
-scrap = { git = "https://github.com/ncatelli/scrap", branch = "main" }
+scrap = { git = "https://github.com/ncatelli/scrap", tag = "v1.0.0" }
 isa-mos6502 = { git = "https://github.com/ncatelli/isa-mos6502", tag = "v0.2.0" }


### PR DESCRIPTION
# Introduction
This PR sets the scrap dependency to track the v1.0.0 tag rather than the main branch. Additionally this updates the cli to use the supplied help_string.
# Linked Issues
resolves #116 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
